### PR TITLE
Support embedding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.db
+*.db*
 *.dwarf
 /.shards/
 /bin/

--- a/README.md
+++ b/README.md
@@ -191,6 +191,37 @@ track of the state changes (which migration were applied, when were applied),
 the migrator uses a dedicated table named `drift_migrations` that is
 automatically created if not found.
 
+#### Embedding migrations
+
+By default, Drift will load and use migration files from the filesystem. This
+approach works great during development, but it increases complexity for
+distribution of binaries.
+
+To help with that, `Drift.embed_as` macro is available, which will collect
+all the migration files from the filesystem and bundles them within the
+generated executable, removing the need to distribute them along your
+application.
+
+```crystal
+require "sqlite3"
+require "drift"
+
+Drift.embed_as("my_migrations", "database/migrations")
+
+db = DB.connect "sqlite3:app.db"
+
+migrator = Drift::Migrator.new(db, my_migrations)
+migrator.apply!
+
+db.close
+```
+
+In the above example, `Drift.embed_as` created `my_migrations` method
+bundling all the migrations found in `database/migrations` directory.
+
+When using classes or modules, you can also define instance or class methods
+by prepending `self.` to the method name to use by Drift.
+
 ## Contribution policy
 
 Inspired by [Litestream](https://github.com/benbjohnson/litestream) and

--- a/src/drift.cr
+++ b/src/drift.cr
@@ -18,6 +18,9 @@ module Drift
   # :nodoc:
   ID_PATTERN = /(^[0-9]+)/
 
+  # Default migrations location
+  MIGRATIONS_PATH = "database/migrations"
+
   # :nodoc:
   class Error < Exception
   end

--- a/src/drift/commands/command.cr
+++ b/src/drift/commands/command.cr
@@ -20,7 +20,7 @@ require "db"
 module Drift
   module Commands
     class Options
-      property migrations_path : String = "database/migrations"
+      property migrations_path : String = Drift::MIGRATIONS_PATH
       property db_url : URI? { ENV["DB_URL"]?.try { |uri| URI.parse(uri) } }
 
       def self.from_parser(parser : OptionParser)

--- a/src/drift/context.cr
+++ b/src/drift/context.cr
@@ -37,7 +37,7 @@ module Drift
 
     def load_path(path : String)
       # build a list of .sql files to load
-      migration_files = Dir.glob(File.join(path, "*.sql"))
+      migration_files = Dir.glob(File.join(path, "*.sql")).sort!
 
       # extract the IDs of found filenames for mapping
       migration_files.each do |filename|

--- a/src/drift/embed.cr
+++ b/src/drift/embed.cr
@@ -1,0 +1,25 @@
+# Copyright 2024 Luis Lavena
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Drift
+  macro embed_as(name, path, dir = __DIR__)
+    def {{ name.id }} : Drift::Context
+      ctx = Drift::Context.new
+
+      {{ run("./drift/support/migrations_loader.cr", path, dir) }}
+
+      ctx
+    end
+  end
+end

--- a/src/drift/support/migrations_loader.cr
+++ b/src/drift/support/migrations_loader.cr
@@ -1,3 +1,17 @@
+# Copyright 2024 Luis Lavena
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Drift
   module Support
     # :nodoc:

--- a/src/drift/support/migrations_loader.cr
+++ b/src/drift/support/migrations_loader.cr
@@ -1,0 +1,34 @@
+module Drift
+  module Support
+    # :nodoc:
+    ID_PATTERN = /(^[0-9]+)/
+
+    class MigrationsLoader
+      def initialize(@io : IO, @path : String)
+      end
+
+      def run
+        migration_files = Dir.glob(File.join(@path, "*.sql")).sort!
+
+        migration_files.each do |path|
+          filename = File.basename(path)
+
+          # ctx.add Drift::Migration.from_io(SQL, id, filename)\n
+
+          @io << "# #{filename}\n"
+          @io << "ctx.add Drift::Migration.from_io("
+          File.read(path).inspect(@io)
+          @io << ", "
+          @io << ID_PATTERN.match(filename).try &.[1]
+          @io << ", "
+          filename.inspect(@io)
+          @io << ")\n\n"
+        end
+      end
+    end
+  end
+end
+
+path = File.expand_path(ARGV[0], ARGV[1])
+
+Drift::Support::MigrationsLoader.new(STDOUT, path).run


### PR DESCRIPTION
Allow `Drift.embed_as` macro to create a `method` that will contains all the migrations found in the supplied `path`.

This macro will help with scenarios that migration files needs to be included within the executable to facilitate distribution and deployment.

Some usage examples:

```crystal
require "sqlite3"
require "drift"

Drift.embed_as("my_migrations", "database/migrations")

db = DB.connect "sqlite3:app.db"

migrator = Drift::Migrator.new(db, my_migrations)
migrator.apply!

db.close
```