### PR TITLE
Fixes duplicate tagging step in CI

### DIFF
--- a/.changes/unreleased/internal-20250303-002036.yaml
+++ b/.changes/unreleased/internal-20250303-002036.yaml
@@ -1,0 +1,5 @@
+kind: internal
+body: Fix duplicate release tagging in CI
+time: 2025-03-03T00:20:36.766473+01:00
+custom:
+    Issue: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,13 +131,6 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
-          git tag -a ${{ steps.latest.outputs.output }} -m "Release ${{ steps.latest.outputs.output }}"
-          git push --tags
-
-      - name: Create tag
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
           git tag -a ${{ env.RELEASE_TAG }} -m "Release ${{ env.RELEASE_TAG }}"
           git push --tags
 


### PR DESCRIPTION
Refactor of the step caused referencing previous captured values instead of environment variables exposed.