### PR TITLE
Adds support for multi-statement migration blocks

### DIFF
--- a/.changes/unreleased/improved-20250303-011256.yaml
+++ b/.changes/unreleased/improved-20250303-011256.yaml
@@ -1,0 +1,5 @@
+kind: improved
+body: Migrations now support multi-statement blocks
+time: 2025-03-03T01:12:56.962111+01:00
+custom:
+    Issue: "2"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,33 @@ CREATE TABLE users (
 DROP TABLE IF EXISTS users;
 ```
 
+For complex SQL statements that include semicolons within the statement itself
+(like triggers, functions, or procedures), you can use the special comments
+`-- drift:begin` and `-- drift:end` to wrap the entire statement:
+
+```sql
+-- drift:migrate
+-- drift:begin
+CREATE TRIGGER update_timestamp AFTER
+UPDATE ON users BEGIN
+UPDATE users
+SET
+    last_modified = CURRENT_TIMESTAMP
+WHERE
+    id = NEW.id;
+
+INSERT INTO
+    audit_log (user_id, action)
+VALUES
+    (NEW.id, 'updated');
+
+END;
+-- drift:end
+
+-- drift:rollback
+DROP TRIGGER IF EXISTS update_timestamp;
+```
+
 Each migration must be identified by a unique ID. The recommended pattern for
 this is to generate those IDs using dates and time. Eg. `20220601204500` as
 ID translates to a migration created June 1st, 2022 at 8:45pm.

--- a/spec/drift/migration_spec.cr
+++ b/spec/drift/migration_spec.cr
@@ -121,21 +121,6 @@ describe Drift::Migration do
         create_statement.should eq(create_statement)
       end
 
-      it "handles statements that don't end with a semicolon" do
-        content = <<-SQL
-          -- drift:migrate
-          CREATE TABLE users (
-            id INTEGER PRIMARY KEY,
-            name TEXT NOT NULL
-          )
-          SQL
-
-        migration = Drift::Migration.from_io(content, 1)
-
-        migration.statements_for(:migrate).size.should eq(1)
-        migration.statements_for(:migrate).first.should contain("CREATE TABLE users")
-      end
-
       it "handles mixing regular statements with multi-statement blocks" do
         mixed_statement = <<-SQL
           -- drift:migrate

--- a/spec/drift/migration_spec.cr
+++ b/spec/drift/migration_spec.cr
@@ -120,6 +120,58 @@ describe Drift::Migration do
         create_statement = migration.statements_for(:migrate).first
         create_statement.should eq(create_statement)
       end
+
+      it "handles statements that don't end with a semicolon" do
+        content = <<-SQL
+          -- drift:migrate
+          CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL
+          )
+          SQL
+
+        migration = Drift::Migration.from_io(content, 1)
+
+        migration.statements_for(:migrate).size.should eq(1)
+        migration.statements_for(:migrate).first.should contain("CREATE TABLE users")
+      end
+
+      it "handles mixing regular statements with multi-statement blocks" do
+        mixed_statement = <<-SQL
+          -- drift:migrate
+          CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            created_at TIMESTAMP,
+            updated_at TIMESTAMP
+          );
+
+          -- drift:begin
+          CREATE TRIGGER set_timestamp_on_insert
+          BEFORE INSERT ON users
+          FOR EACH ROW
+          BEGIN
+            NEW.created_at = CURRENT_TIMESTAMP;
+            NEW.updated_at = CURRENT_TIMESTAMP;
+          END;
+          -- drift:end
+
+          CREATE INDEX idx_users_name ON users(name);
+
+          -- drift:rollback
+          DROP INDEX IF EXISTS idx_users_name;
+          DROP TRIGGER IF EXISTS set_timestamp_on_insert;
+          DROP TABLE IF EXISTS users;
+          SQL
+
+        migration = Drift::Migration.from_io(mixed_statement, 1)
+
+        # Should have 3 migrate statements: table creation, trigger, and index
+        migration.statements_for(:migrate).size.should eq(3)
+
+        # Should have 3 rollback statements: index drop, trigger drop, and table drop
+        migration.statements_for(:rollback).size.should eq(3)
+      end
     end
   end
 
@@ -132,6 +184,20 @@ describe Drift::Migration do
       migration.filename.should eq("20211219152312_create_humans.sql")
       migration.statements_for(:migrate).size.should eq(2)
       migration.statements_for(:rollback).size.should eq(2)
+    end
+
+    it "loads multi-statement migration with begin/end markers correctly" do
+      file_path = fixture_path("trigger", "20250302234927_create_timestamp_trigger.sql")
+      migration = Drift::Migration.load_file(file_path)
+
+      migration.statements_for(:migrate).size.should eq(1)
+      migrate_stmt = migration.statements_for(:migrate).first
+      migrate_stmt.should contain("CREATE TRIGGER update_timestamp")
+      migrate_stmt.should contain("UPDATE employees")
+      migrate_stmt.should contain("INSERT INTO")
+
+      migration.statements_for(:rollback).size.should eq(1)
+      migration.statements_for(:rollback).first.should eq("DROP TRIGGER IF EXISTS update_timestamp;")
     end
 
     it "raises error when unable to determine migration ID" do

--- a/spec/fixtures/trigger/20250302234904_create_employees.sql
+++ b/spec/fixtures/trigger/20250302234904_create_employees.sql
@@ -1,0 +1,12 @@
+-- drift:migrate
+CREATE TABLE IF NOT EXISTS employees (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    position TEXT,
+    salary REAL,
+    hire_date DATE,
+    last_modified TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- drift:rollback
+DROP TABLE IF EXISTS employees;

--- a/spec/fixtures/trigger/20250302234910_create_audit_log.sql
+++ b/spec/fixtures/trigger/20250302234910_create_audit_log.sql
@@ -1,0 +1,11 @@
+-- drift:migrate
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY,
+    employee_id INTEGER NOT NULL,
+    action TEXT NOT NULL,
+    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (employee_id) REFERENCES employees (id)
+);
+
+-- drift:rollback
+DROP TABLE IF EXISTS audit_log;

--- a/spec/fixtures/trigger/20250302234927_create_timestamp_trigger.sql
+++ b/spec/fixtures/trigger/20250302234927_create_timestamp_trigger.sql
@@ -1,0 +1,20 @@
+-- drift:migrate
+-- drift:begin
+CREATE TRIGGER update_timestamp AFTER
+UPDATE ON employees BEGIN
+UPDATE employees
+SET
+    last_modified = CURRENT_TIMESTAMP
+WHERE
+    id = NEW.id;
+
+INSERT INTO
+    audit_log (employee_id, action)
+VALUES
+    (NEW.id, 'updated');
+
+END;
+-- drift:end
+
+-- drift:rollback
+DROP TRIGGER IF EXISTS update_timestamp;

--- a/src/drift/migration.cr
+++ b/src/drift/migration.cr
@@ -95,11 +95,6 @@ module Drift
         end
       end
 
-      # Handle case where file ends without a semicolon
-      if !buffer.empty? && type && !multi_statement_mode
-        migration.add(type, buffer.to_s.strip)
-      end
-
       migration
     end
 


### PR DESCRIPTION
Enables handling of complex SQL statements like triggers, functions, or procedures that contain internal semicolons.

Previously, these statements would be incorrectly split into separate statements when parsed.

Introduces two special markers: `-- drift:begin` and `-- drift:end` to wrap multi-statement blocks. All contents between these markers are treated as a single statement and all semicolons within these blocks will not result in separate statements.

Fixes #2