### PR TITLE
Raise errors when an option is missing or invalid

### DIFF
--- a/.changes/unreleased/fixed-20250722-231257.yaml
+++ b/.changes/unreleased/fixed-20250722-231257.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Fix unhandled exceptions for unknown or missing options
+time: 2025-07-22T23:12:57.075968+02:00
+custom:
+    Issue: ""

--- a/src/drift/commands/command.cr
+++ b/src/drift/commands/command.cr
@@ -34,6 +34,10 @@ module Drift
           options.migrations_path = value
         end
 
+        parser.invalid_option do |flag|
+          raise Drift::Error.new("#{flag} is not a valid option.")
+        end
+
         options
       end
     end

--- a/src/drift/commands/command.cr
+++ b/src/drift/commands/command.cr
@@ -38,6 +38,10 @@ module Drift
           raise Drift::Error.new("#{flag} is not a valid option.")
         end
 
+        parser.missing_option do |flag|
+          raise Drift::Error.new("Missing option: #{flag}.")
+        end
+
         options
       end
     end


### PR DESCRIPTION
Hi,
This PR provides changes where options are raised when the option is invalid or missing, thanks to `Drift::Error`. This allows to print only the message error and avoid displaying the backtrace.

## Before

```
~ # drift --example-option
Usage: drift [<command>]

Commands:
    help                             Show this page (default)
    migrate                          Apply migrations
    new <migration>                  Create a new migration file
    reset                            Rollback all applied migrations
    rollback                         Rollback last migration batch
    status                           Display current migrations status
    version                          Show application version

General options:
    --db URI, -d URI                 URI for the database
    --path DIR                       Directory that contains migration files
Unhandled exception: Invalid option: --example-option (OptionParser::InvalidOption)
  from ???
  from ???
  from ???
  from ???
  from ???
```

## After

A message error will be displayed when using the option that doesn't exist.

```
/workspace/drift $ bin/drift --example-option
Usage: drift [<command>]

Commands:
    help                             Show this page (default)
    migrate                          Apply migrations
    new <migration>                  Create a new migration file
    reset                            Rollback all applied migrations
    rollback                         Rollback last migration batch
    status                           Display current migrations status
    version                          Show application version

General options:
    --db URI, -d URI                 URI for the database
    --path DIR                       Directory that contains migration files
ERROR: --example-option is not a valid option.
```

For example, the missing option will be trigerred when the `--db` option has not the value. 

```
/workspace/drift $ bin/drift migrate --db
ERROR: Missing option: --db.
```