### PR TITLE
Fix tip release build

### DIFF
--- a/.changes/unreleased/internal-20250714-010756.yaml
+++ b/.changes/unreleased/internal-20250714-010756.yaml
@@ -1,0 +1,5 @@
+kind: internal
+body: Build all supported platforms during nightly (tip)
+time: 2025-07-14T01:07:56.820653+02:00
+custom:
+    Issue: ""

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -28,8 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set build numbers
         run: |
-          LAST_TAG=$(git tag --sort=-version:refname | head -1)
-          echo "DRIFT_BUILD=$(git rev-list --count $LAST_TAG..)" >> $GITHUB_ENV
+          echo "DRIFT_BUILD=$(git rev-list --count HEAD)" >> $GITHUB_ENV
           echo "DRIFT_COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build prerelease version

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -58,8 +58,8 @@ jobs:
     strategy:
       matrix:
         platform:
-          # - x86_64-linux-musl
-          # - aarch64-linux-musl
+          - x86_64-linux-musl
+          - aarch64-linux-musl
           - aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- No longer depend on previous tags to compute build number
- Produce artifacts for all supported platforms