### PR TITLE
Computes build number relative to previous release

### DIFF
--- a/.changes/unreleased/internal-20250714-012344.yaml
+++ b/.changes/unreleased/internal-20250714-012344.yaml
@@ -1,0 +1,5 @@
+kind: internal
+body: Uses release-relative build number for nightly builds
+time: 2025-07-14T01:23:44.571327+02:00
+custom:
+    Issue: ""

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -26,9 +26,14 @@ jobs:
       version: ${{ steps.latest_version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Important so that build number generation works
+          fetch-depth: 0
+
       - name: Set build numbers
         run: |
-          echo "DRIFT_BUILD=$(git rev-list --count HEAD)" >> $GITHUB_ENV
+          LAST_TAG=$(git tag --sort=-version:refname | head -1)
+          echo "DRIFT_BUILD=$(git rev-list --count $LAST_TAG..HEAD)" >> $GITHUB_ENV
           echo "DRIFT_COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build prerelease version


### PR DESCRIPTION
Fixes the workaround from bb480391e5c04c72a6065d081f6b88696e4de101, by cloning the repository with all the history.