### PR TITLE
Fully run `setup` commands inside container

### DIFF
--- a/.changes/unreleased/internal-20250714-035125.yaml
+++ b/.changes/unreleased/internal-20250714-035125.yaml
@@ -1,0 +1,5 @@
+kind: internal
+body: Fix 'make setup' when shard.lock is missing
+time: 2025-07-14T03:51:25.947724+02:00
+custom:
+    Issue: ""

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ restart: ## restart the containers
 
 setup: ## initialize the project
 	@docker compose build app
-	@docker compose run --rm app -- shards check || shards install
+	@docker compose run --rm app -- sh -c '(shards check || shards install)'
 
 stop: ## stop running containers
 	@docker compose down


### PR DESCRIPTION
Ensures shards check || shards install are both executed within the container and not the host due shard.lock being missing.