### PR TITLE
Support other SQL dialects (MySQL, PostgreSQL)

### DIFF
--- a/.changes/unreleased/added-20251012-201335.yaml
+++ b/.changes/unreleased/added-20251012-201335.yaml
@@ -1,0 +1,5 @@
+kind: added
+body: Support PostgreSQL as library or CLI
+time: 2025-10-12T20:13:35.619382+02:00
+custom:
+    Issue: ""

--- a/.changes/unreleased/added-20251013-003617.yaml
+++ b/.changes/unreleased/added-20251013-003617.yaml
@@ -1,0 +1,5 @@
+kind: added
+body: Support MySQL databases as library or via CLI
+time: 2025-10-13T00:36:17.19928+02:00
+custom:
+    Issue: ""

--- a/.changes/unreleased/deprecated-20251011-193908.yaml
+++ b/.changes/unreleased/deprecated-20251011-193908.yaml
@@ -1,0 +1,5 @@
+kind: deprecated
+body: Limit Drift::Migrator to DB::Database types
+time: 2025-10-11T19:39:08.945847+02:00
+custom:
+    Issue: ""

--- a/.changes/unreleased/improved-20251011-195702.yaml
+++ b/.changes/unreleased/improved-20251011-195702.yaml
@@ -1,0 +1,5 @@
+kind: improved
+body: Abstract Migrator SQL operations as Dialect implementation
+time: 2025-10-11T19:57:02.013986+02:00
+custom:
+    Issue: ""

--- a/.changes/unreleased/improved-20251012-125124.yaml
+++ b/.changes/unreleased/improved-20251012-125124.yaml
@@ -1,0 +1,5 @@
+kind: improved
+body: Optimize rollback plan calculations and memory usage
+time: 2025-10-12T12:51:24.699334+02:00
+custom:
+    Issue: ""

--- a/.changes/unreleased/internal-20251012-133617.yaml
+++ b/.changes/unreleased/internal-20251012-133617.yaml
@@ -1,0 +1,5 @@
+kind: internal
+body: Adds PostgreSQL container for development/testing
+time: 2025-10-12T13:36:17.161299+02:00
+custom:
+    Issue: ""

--- a/.changes/unreleased/internal-20251012-151331.yaml
+++ b/.changes/unreleased/internal-20251012-151331.yaml
@@ -1,0 +1,5 @@
+kind: internal
+body: Move SQLite3 dependency to only development mode
+time: 2025-10-12T15:13:31.081418+02:00
+custom:
+    Issue: ""

--- a/.changes/unreleased/internal-20251013-003809.yaml
+++ b/.changes/unreleased/internal-20251013-003809.yaml
@@ -1,0 +1,5 @@
+kind: internal
+body: Add MySQL container for local and CI testing
+time: 2025-10-13T00:38:09.800223+02:00
+custom:
+    Issue: ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,12 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v4
       - uses: crystal-lang/install-crystal@v1
       - run: shards install
       - run: crystal spec
         env:
-          POSTGRES_DB_URL: postgres://drift:drift@postgres:5432/drift_test
+          POSTGRES_DB_URL: postgres://drift:drift@localhost:5432/drift_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mysql:
-        image: mysql:8.0-oracle
+        image: mysql:5.7
         env:
           MYSQL_DATABASE: drift_test
           MYSQL_USER: drift
@@ -42,7 +42,6 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
-          --default-authentication-plugin=mysql_native_password
         ports:
           - 3306:3306
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
     services:
+      mysql:
+        image: mysql:8.0-oracle
+        env:
+          MYSQL_DATABASE: drift_test
+          MYSQL_USER: drift
+          MYSQL_PASSWORD: drift
+          MYSQL_ROOT_PASSWORD: drift_root
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+          --default-authentication-plugin=mysql_native_password
+        ports:
+          - 3306:3306
       postgres:
         image: postgres:18-alpine
         env:
@@ -49,4 +64,5 @@ jobs:
       - run: shards install
       - run: crystal spec
         env:
+          MYSQL_DB_URL: mysql://drift:drift@localhost:3306/drift_test
           POSTGRES_DB_URL: postgres://drift:drift@localhost:5432/drift_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,22 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_DB: drift_test
+          POSTGRES_USER: drift
+          POSTGRES_PASSWORD: drift
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: crystal-lang/install-crystal@v1
       - run: shards install
       - run: crystal spec
+        env:
+          POSTGRES_DB_URL: postgres://drift:drift@postgres:5432/drift_test

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ export FIXGID
 # Make `help` the default task
 .DEFAULT_GOAL := help
 
-.PHONY: build console logs restart setup start stop help
+.PHONY: console dev help restart setup stop
 
 console: ## start a console session
 	@docker compose exec app sh -i 2>/dev/null || docker compose run --rm app -- sh -i

--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ in reverse order using the information on the previously mentioned table.
 ## Requirements
 
 Drift CLI is a standalone, self-contained executable capable of connecting to
-SQLite databases.
+the following databases (dialects):
+
+* PostgreSQL
+* SQLite3
 
 Drift (as library) only depends on Crystal's
 [`db`](https://github.com/crystal-lang/crystal-db) common API. To use it with
@@ -190,6 +193,20 @@ require "sqlite3"
 require "drift"
 
 db = DB.open "sqlite3:app.db"
+
+migrator = Drift::Migrator.from_path(db, "database/migrations")
+migrator.apply!
+
+db.close
+```
+
+Or for a PostgreSQL database:
+
+```crystal
+require "pg"
+require "drift"
+
+db = DB.open "postgres://user:password@localhost/dbname"
 
 migrator = Drift::Migrator.from_path(db, "database/migrations")
 migrator.apply!

--- a/README.md
+++ b/README.md
@@ -98,12 +98,13 @@ in reverse order using the information on the previously mentioned table.
 Drift CLI is a standalone, self-contained executable capable of connecting to
 the following databases (dialects):
 
+* MySQL
 * PostgreSQL
 * SQLite3
 
 Drift (as library) only depends on Crystal's
 [`db`](https://github.com/crystal-lang/crystal-db) common API. To use it with
-to specific adapters, you need to add the respective dependencies and require
+specific adapters, you need to add the respective dependencies and require
 them part of your application. See more about in the
 [library usage](#as-library-crystal-shard) section.
 
@@ -200,6 +201,20 @@ migrator.apply!
 db.close
 ```
 
+For a MySQL database:
+
+```crystal
+require "mysql"
+require "drift"
+
+db = DB.open "mysql://user:password@localhost/dbname"
+
+migrator = Drift::Migrator.from_path(db, "database/migrations")
+migrator.apply!
+
+db.close
+```
+
 Or for a PostgreSQL database:
 
 ```crystal
@@ -267,6 +282,32 @@ bundling all the migrations found in `database/migrations` directory.
 
 When using classes or modules, you can also define instance or class methods
 by prepending `self.` to the method name to use by Drift.
+
+## Development
+
+### Running tests
+
+By default, tests run against all supported databases (MySQL, PostgreSQL,
+SQLite3).
+
+To skip specific databases:
+
+```console
+$ SKIP_MYSQL=true crystal spec        # Skip MySQL tests
+$ SKIP_POSTGRESQL=true crystal spec   # Skip PostgreSQL tests
+```
+
+Start database services with Docker Compose:
+
+```console
+$ docker compose up -d mysql postgres
+```
+
+Stop database services:
+
+```console
+$ docker compose down
+```
 
 ## Contribution policy
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ application:
 require "sqlite3"
 require "drift"
 
-db = DB.connect "sqlite3:app.db"
+db = DB.open "sqlite3:app.db"
 
 migrator = Drift::Migrator.from_path(db, "database/migrations")
 migrator.apply!
@@ -237,7 +237,7 @@ require "drift"
 
 Drift.embed_as("my_migrations", "database/migrations")
 
-db = DB.connect "sqlite3:app.db"
+db = DB.open "sqlite3:app.db"
 
 migrator = Drift::Migrator.new(db, my_migrations)
 migrator.apply!

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,8 @@ services:
       - .:/workspace/${COMPOSE_PROJECT_NAME}:cached
 
   mysql:
-    image: mysql:8-oracle
+    image: mysql:8.0-oracle
+    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_DATABASE: drift_test
       MYSQL_USER: drift

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,7 @@ services:
     command: overmind start -f Procfile.dev
     working_dir: /workspace/${COMPOSE_PROJECT_NAME}
     depends_on:
+      - mysql
       - postgres
     environment:
       # Workaround Overmind socket issues with Vite
@@ -12,6 +13,7 @@ services:
       # Disable Shards' postinstall
       - SHARDS_OPTS=--skip-postinstall
       # Test DBs
+      - MYSQL_DB_URL=mysql://drift:drift@mysql:3306/drift_test
       - POSTGRES_DB_URL=postgres://drift:drift@postgres:5432/drift_test
 
     # Set these env variables using `export FIXUID=$(id -u) FIXGID=$(id -g)`
@@ -19,6 +21,21 @@ services:
 
     volumes:
       - .:/workspace/${COMPOSE_PROJECT_NAME}:cached
+
+  mysql:
+    image: mysql:8-oracle
+    environment:
+      MYSQL_DATABASE: drift_test
+      MYSQL_USER: drift
+      MYSQL_PASSWORD: drift
+      MYSQL_ROOT_PASSWORD: drift_root
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+    volumes:
+      - mysql:/var/lib/mysql
 
   postgres:
     image: postgres:18-alpine
@@ -35,5 +52,7 @@ services:
       - postgres:/var/lib/postgresql
 
 volumes:
+  mysql:
+    driver: local
   postgres:
     driver: local

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,15 +3,37 @@ services:
     image: ghcr.io/luislavena/hydrofoil-crystal:${CRYSTAL_VERSION:-1.16}
     command: overmind start -f Procfile.dev
     working_dir: /workspace/${COMPOSE_PROJECT_NAME}
+    depends_on:
+      - postgres
     environment:
       # Workaround Overmind socket issues with Vite
       # Ref: https://github.com/luislavena/hydrofoil-crystal/issues/66
       - OVERMIND_SOCKET=/tmp/overmind.sock
       # Disable Shards' postinstall
       - SHARDS_OPTS=--skip-postinstall
+      # Test DBs
+      - POSTGRES_DB_URL=postgres://drift:drift@postgres:5432/drift_test
 
     # Set these env variables using `export FIXUID=$(id -u) FIXGID=$(id -g)`
     user: ${FIXUID:-1000}:${FIXGID:-1000}
 
     volumes:
       - .:/workspace/${COMPOSE_PROJECT_NAME}:cached
+
+  postgres:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_DB: drift_test
+      POSTGRES_USER: drift
+      POSTGRES_PASSWORD: drift
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+    volumes:
+      - postgres:/var/lib/postgresql
+
+volumes:
+  postgres:
+    driver: local

--- a/shard.yml
+++ b/shard.yml
@@ -12,6 +12,9 @@ dependencies:
     github: crystal-lang/crystal-db
     version: ~> 0.14.0
 development_dependencies:
+  mysql:
+    github: crystal-lang/crystal-mysql
+    version: ~> 0.17.0
   pg:
     github: will/crystal-pg
     # FIXME: lock until new crystal-pg release

--- a/shard.yml
+++ b/shard.yml
@@ -12,6 +12,10 @@ dependencies:
     github: crystal-lang/crystal-db
     version: ~> 0.14.0
 development_dependencies:
+  pg:
+    github: will/crystal-pg
+    # FIXME: lock until new crystal-pg release
+    commit: c5b8ac1ac5713fc58f974d8a4327887a0b297594
   sqlite3:
     github: crystal-lang/crystal-sqlite3
     version: ~> 0.22.0

--- a/shard.yml
+++ b/shard.yml
@@ -11,6 +11,7 @@ dependencies:
   db:
     github: crystal-lang/crystal-db
     version: ~> 0.14.0
+development_dependencies:
   sqlite3:
     github: crystal-lang/crystal-sqlite3
     version: ~> 0.22.0

--- a/spec/drift/dialect_spec.cr
+++ b/spec/drift/dialect_spec.cr
@@ -14,6 +14,7 @@
 
 require "../spec_helper"
 
+require "pg"
 require "sqlite3"
 
 describe Drift::Dialect do
@@ -23,6 +24,15 @@ describe Drift::Dialect do
       dialect = Drift::Dialect.from_db(db)
 
       dialect.should be_a(Drift::Dialect::SQLite3)
+
+      db.close
+    end
+
+    it "detects PostgreSQL dialect" do
+      db = DB.open(ENV["POSTGRES_DB_URL"]? || "postgres://drift:drift@localhost:5432/drift")
+      dialect = Drift::Dialect.from_db(db)
+
+      dialect.should be_a(Drift::Dialect::PostgreSQL)
 
       db.close
     end

--- a/spec/drift/dialect_spec.cr
+++ b/spec/drift/dialect_spec.cr
@@ -14,6 +14,7 @@
 
 require "../spec_helper"
 
+require "mysql"
 require "pg"
 require "sqlite3"
 
@@ -33,6 +34,15 @@ describe Drift::Dialect do
       dialect = Drift::Dialect.from_db(db)
 
       dialect.should be_a(Drift::Dialect::PostgreSQL)
+
+      db.close
+    end
+
+    it "detects MySQL dialect" do
+      db = DB.open(ENV["MYSQL_DB_URL"]? || "mysql://drift:drift@localhost:3306/drift_test")
+      dialect = Drift::Dialect.from_db(db)
+
+      dialect.should be_a(Drift::Dialect::MySQL)
 
       db.close
     end

--- a/spec/drift/dialect_spec.cr
+++ b/spec/drift/dialect_spec.cr
@@ -1,0 +1,30 @@
+# Copyright 2022 Luis Lavena
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "../spec_helper"
+
+require "sqlite3"
+
+describe Drift::Dialect do
+  describe ".from_db" do
+    it "detects SQLite3 dialect" do
+      db = DB.open("sqlite3:%3Amemory%3A")
+      dialect = Drift::Dialect.from_db(db)
+
+      dialect.should be_a(Drift::Dialect::SQLite3)
+
+      db.close
+    end
+  end
+end

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -14,6 +14,7 @@
 
 require "../spec_helper"
 
+require "mysql"
 require "pg"
 require "sqlite3"
 
@@ -25,6 +26,10 @@ DIALECTS = {
   },
   postgresql: {
     url:           ENV["POSTGRES_DB_URL"]? || "postgres://drift:drift@localhost:5432/drift_test",
+    needs_cleanup: true,
+  },
+  mysql: {
+    url:           ENV["MYSQL_DB_URL"]? || "mysql://drift:drift@localhost:3306/drift_test",
     needs_cleanup: true,
   },
 }
@@ -48,12 +53,14 @@ private def create_dummy(db)
     db.exec("CREATE TABLE IF NOT EXISTS dummy (id INTEGER PRIMARY KEY NOT NULL, value INTEGER NOT NULL);")
   when Drift::Dialect::PostgreSQL
     db.exec("CREATE TABLE IF NOT EXISTS dummy (id BIGSERIAL PRIMARY KEY NOT NULL, value BIGINT NOT NULL);")
+  when Drift::Dialect::MySQL
+    db.exec("CREATE TABLE IF NOT EXISTS dummy (id BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL, value BIGINT NOT NULL);")
   end
 end
 
 private def fake_migration(db, id = 1, batch = 1)
   case Drift::Dialect.from_db(db)
-  when Drift::Dialect::SQLite3
+  when Drift::Dialect::SQLite3, Drift::Dialect::MySQL
     db.exec("INSERT INTO drift_migrations (id, batch, applied_at, duration_ns) VALUES (?, ?, ?, ?);", id, batch, Time.utc, 100000)
   when Drift::Dialect::PostgreSQL
     db.exec("INSERT INTO drift_migrations (id, batch, applied_at, duration_ns) VALUES ($1, $2, $3, $4);", id, batch, Time.utc, 100000)
@@ -94,7 +101,8 @@ end
 macro for_each_dialect
   {% for name, config in DIALECTS %}
     {% skip_postgresql = env("SKIP_POSTGRESQL") == "true" %}
-    {% unless name.id == "postgresql" && skip_postgresql %}
+    {% skip_mysql = env("SKIP_MYSQL") == "true" %}
+    {% unless (name.id == "postgresql" && skip_postgresql) || (name.id == "mysql" && skip_mysql) %}
       describe "with {{ name.id }}" do
         # Proc to get a clean DB connection for this dialect
         dialect_db = ->() {

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -14,19 +14,18 @@
 
 require "../spec_helper"
 
+require "pg"
 require "sqlite3"
 
 # Configuration for dialects to test
 DIALECTS = {
   sqlite3: {
-    url: ENV["SQLITE3_DB_URL"]? || "sqlite3:%3Amemory%3A",
+    url:           ENV["SQLITE3_DB_URL"]? || "sqlite3:%3Amemory%3A",
     needs_cleanup: false,
-    skip: false,
   },
   postgresql: {
-    url: ENV["POSTGRES_DB_URL"]? || "postgres://drift:drift@localhost:5432/drift_test",
+    url:           ENV["POSTGRES_DB_URL"]? || "postgres://drift:drift@localhost:5432/drift_test",
     needs_cleanup: true,
-    skip: ENV["SKIP_POSTGRESQL"]? == "true",
   },
 }
 
@@ -94,7 +93,8 @@ end
 # Macro to run tests for each dialect
 macro for_each_dialect
   {% for name, config in DIALECTS %}
-    {% unless config[:skip] %}
+    {% skip_postgresql = env("SKIP_POSTGRESQL") == "true" %}
+    {% unless name.id == "postgresql" && skip_postgresql %}
       describe "with {{ name.id }}" do
         # Proc to get a clean DB connection for this dialect
         dialect_db = ->() {
@@ -626,429 +626,437 @@ describe Drift::Migrator do
     end
   end
 
-  describe "#rollback_plan" do
-    context "with no migration applied" do
-      it "returns an empty list of migrations" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
+  for_each_dialect do
+    describe "#rollback_plan" do
+      context "with no migration applied" do
+        it "returns an empty list of migrations" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
 
-        ids = migrator.rollback_plan
-        ids.should be_empty
+          ids = migrator.rollback_plan
+          ids.should be_empty
 
-        db.close
+          db.close
+        end
+      end
+
+      context "dealing with batches" do
+        it "returns the list of migrations in reverse order" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1
+          fake_migration db, 2
+
+          ids = migrator.rollback_plan
+          ids.should_not be_empty
+          ids.should eq([2, 1])
+
+          db.close
+        end
+
+        it "returns only the list of migrations in the last batch" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1, 1
+          fake_migration db, 2, 1
+          fake_migration db, 4, 2
+
+          ids = migrator.rollback_plan
+          ids.should_not be_empty
+          ids.should eq([4])
+
+          db.close
+        end
+      end
+
+      context "migrations not available locally" do
+        it "excludes migrations not locally available" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 5
+
+          ids = migrator.rollback_plan
+          ids.should be_empty
+
+          db.close
+        end
       end
     end
 
-    context "dealing with batches" do
-      it "returns the list of migrations in reverse order" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db, 1
-        fake_migration db, 2
+    describe "#reset_plan" do
+      context "with no migration applied" do
+        it "returns an empty list of migrations" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
 
-        ids = migrator.rollback_plan
-        ids.should_not be_empty
-        ids.should eq([2, 1])
+          ids = migrator.reset_plan
+          ids.should be_empty
 
-        db.close
+          db.close
+        end
       end
 
-      it "returns only the list of migrations in the last batch" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db, 1, 1
-        fake_migration db, 2, 1
-        fake_migration db, 4, 2
+      context "with a single batch" do
+        it "returns a list of migrations in reverse order" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1
+          fake_migration db, 3
 
-        ids = migrator.rollback_plan
-        ids.should_not be_empty
-        ids.should eq([4])
+          ids = migrator.reset_plan
+          ids.should_not be_empty
+          ids.should eq([3, 1])
 
-        db.close
+          db.close
+        end
+
+        it "excludes migraitons not locally available" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1
+          fake_migration db, 5
+
+          ids = migrator.reset_plan
+          ids.should_not be_empty
+          ids.should eq([1])
+
+          db.close
+        end
       end
-    end
 
-    context "migrations not available locally" do
-      it "excludes migrations not locally available" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db, 5
+      context "with multiple batches" do
+        it "returns list of migrations in reverse order" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1, 1
+          fake_migration db, 3, 1
+          fake_migration db, 2, 2
+          fake_migration db, 4, 2
 
-        ids = migrator.rollback_plan
-        ids.should be_empty
+          ids = migrator.reset_plan
+          ids.should_not be_empty
+          ids.should eq([4, 2, 3, 1])
 
-        db.close
+          db.close
+        end
       end
     end
   end
 
-  describe "#reset_plan" do
-    context "with no migration applied" do
-      it "returns an empty list of migrations" do
-        db = memory_db
+  for_each_dialect do
+    describe "#pending?" do
+      it "returns true when no migration was applied" do
+        db = dialect_db.call
         _, migrator = prepared_migrator(db)
 
-        ids = migrator.reset_plan
-        ids.should be_empty
+        migrator.pending?.should be_true
 
         db.close
       end
-    end
 
-    context "with a single batch" do
-      it "returns a list of migrations in reverse order" do
-        db = memory_db
+      it "returns false when all migrations were applied" do
+        db = dialect_db.call
         _, migrator = prepared_migrator(db)
         fake_migration db, 1
+        fake_migration db, 2
         fake_migration db, 3
+        fake_migration db, 4
 
-        ids = migrator.reset_plan
-        ids.should_not be_empty
-        ids.should eq([3, 1])
-
-        db.close
-      end
-
-      it "excludes migraitons not locally available" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db, 1
-        fake_migration db, 5
-
-        ids = migrator.reset_plan
-        ids.should_not be_empty
-        ids.should eq([1])
+        migrator.pending?.should be_false
 
         db.close
       end
     end
 
-    context "with multiple batches" do
-      it "returns list of migrations in reverse order" do
-        db = memory_db
+    describe "#apply!" do
+      context "with completely empty database" do
+        it "prepares the migration table and applies migrations" do
+          db = dialect_db.call
+          migrator = ready_migrator(db)
+
+          migrator.apply!
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(4)
+
+          db.close
+        end
+      end
+
+      context "with no existing migration applied" do
+        it "applies all available migrations as single batch" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+          migrator.apply!
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(4)
+          db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
+
+          db.close
+        end
+      end
+
+      context "with existing batches" do
+        it "applies pending migrations as new batch" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1
+          fake_migration db, 3
+
+          db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
+          migrator.apply!
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(4)
+          db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(2)
+
+          db.close
+        end
+      end
+    end
+
+    describe "#reset!" do
+      context "with no migration applied" do
+        it "does nothing" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+          migrator.reset!
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+
+          db.close
+        end
+      end
+
+      context "with some applied migrations" do
+        it "resets the migration status" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1
+          fake_migration db, 3
+
+          migrator.reset!
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+
+          db.close
+        end
+      end
+    end
+  end
+
+  for_each_dialect do
+    describe "(apply callback cycle)" do
+      it "triggers before a migration is applied" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
+
+        count = 0
+        migrator.before_apply do |_|
+          count += 1
+        end
+
+        migrator.apply(1)
+        count.should eq(1)
+
+        db.close
+      end
+
+      it "triggers after a migration has been applied" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
+
+        count = 0
+        migrator.after_apply do |_, _|
+          count += 1
+        end
+
+        migrator.apply(1)
+        count.should eq(1)
+
+        db.close
+      end
+
+      it "triggers callbacks in sequence" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
+
+        events = Array(Symbol).new
+
+        migrator.before_apply do |_|
+          events.push :before
+        end
+
+        migrator.after_apply do |_, _|
+          events.push :after
+        end
+
+        migrator.apply(1)
+        events.should eq([:before, :after])
+
+        db.close
+      end
+
+      it "does not trigger if migration is already applied" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
+        fake_migration db, 1
+
+        count = 0
+        migrator.before_apply do |_|
+          count += 1
+        end
+
+        migrator.after_apply do |_, _|
+          count += 1
+        end
+
+        migrator.apply(1)
+        count.should eq(0)
+
+        db.close
+      end
+    end
+
+    describe "(rollback callback cycle)" do
+      it "triggers before a migration is rolled back" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
+        fake_migration db, 1
+
+        count = 0
+        migrator.before_rollback do |_|
+          count += 1
+        end
+
+        migrator.rollback(1)
+        count.should eq(1)
+
+        db.close
+      end
+
+      it "triggers after a migration has been rolled back" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
+        fake_migration db, 1
+
+        count = 0
+        migrator.after_rollback do |_, _|
+          count += 1
+        end
+
+        migrator.rollback(1)
+        count.should eq(1)
+
+        db.close
+      end
+
+      it "triggers callbacks in sequence" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
+        fake_migration db, 1
+
+        events = Array(Symbol).new
+        migrator.before_rollback do |_|
+          events.push :before
+        end
+
+        migrator.after_rollback do |_, _|
+          events.push :after
+        end
+
+        migrator.rollback(1)
+        events.should eq([:before, :after])
+
+        db.close
+      end
+
+      it "does not trigger if migration is not applied" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
+
+        count = 0
+        migrator.before_apply do |_|
+          count += 1
+        end
+
+        migrator.after_apply do |_, _|
+          count += 1
+        end
+
+        migrator.rollback(1)
+        count.should eq(0)
+
+        db.close
+      end
+
+      it "resets in the right order" do
+        db = dialect_db.call
         _, migrator = prepared_migrator(db)
         fake_migration db, 1, 1
         fake_migration db, 3, 1
         fake_migration db, 2, 2
         fake_migration db, 4, 2
 
-        ids = migrator.reset_plan
-        ids.should_not be_empty
-        ids.should eq([4, 2, 3, 1])
+        before_ids = Array(Int64).new
+        migrator.before_rollback do |id|
+          before_ids.push id
+        end
 
-        db.close
-      end
-    end
-  end
-
-  describe "#pending?" do
-    it "returns true when no migration was applied" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-
-      migrator.pending?.should be_true
-
-      db.close
-    end
-
-    it "returns false when all migrations were applied" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-      fake_migration db, 1
-      fake_migration db, 2
-      fake_migration db, 3
-      fake_migration db, 4
-
-      migrator.pending?.should be_false
-
-      db.close
-    end
-  end
-
-  describe "#apply!" do
-    context "with completely empty database" do
-      it "prepares the migration table and applies migrations" do
-        db = memory_db
-        migrator = ready_migrator(db)
-
-        migrator.apply!
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(4)
-
-        db.close
-      end
-    end
-
-    context "with no existing migration applied" do
-      it "applies all available migrations as single batch" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
-        migrator.apply!
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(4)
-        db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
-
-        db.close
-      end
-    end
-
-    context "with existing batches" do
-      it "applies pending migrations as new batch" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db, 1
-        fake_migration db, 3
-
-        db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
-        migrator.apply!
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(4)
-        db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(2)
-
-        db.close
-      end
-    end
-  end
-
-  describe "#reset!" do
-    context "with no migration applied" do
-      it "does nothing" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
-        migrator.reset!
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
-
-        db.close
-      end
-    end
-
-    context "with some applied migrations" do
-      it "resets the migration status" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db, 1
-        fake_migration db, 3
+        after_ids = Array(Int64).new
+        migrator.after_rollback do |id, _|
+          after_ids.push id
+        end
 
         migrator.reset!
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+        before_ids.size.should eq(4)
+        after_ids.size.should eq(4)
+        before_ids.should eq([4, 2, 3, 1])
+        after_ids.should eq([4, 2, 3, 1])
 
         db.close
       end
     end
   end
 
-  describe "(apply callback cycle)" do
-    it "triggers before a migration is applied" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
+  for_each_dialect do
+    describe "#applied" do
+      it "returns an empty list when no migrations were applied" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
 
-      count = 0
-      migrator.before_apply do |_|
-        count += 1
+        migrator.applied.should be_empty
+
+        db.close
       end
 
-      migrator.apply(1)
-      count.should eq(1)
+      it "returns ordered list of applied migrations" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
+        fake_migration db, 1
+        fake_migration db, 2
 
-      db.close
-    end
+        entries = migrator.applied
+        entries.should_not be_empty
+        entries.size.should eq(2)
 
-    it "triggers after a migration has been applied" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
+        mig1 = entries.first
+        mig1.id.should eq(1)
 
-      count = 0
-      migrator.after_apply do |_, _|
-        count += 1
+        db.close
       end
 
-      migrator.apply(1)
-      count.should eq(1)
+      it "returns only known applied migrations" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
+        fake_migration db, 2
+        fake_migration db, 5
 
-      db.close
-    end
+        entries = migrator.applied
+        entries.size.should eq(1)
 
-    it "triggers callbacks in sequence" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
+        mig2 = entries.first
+        mig2.id.should eq(2)
 
-      events = Array(Symbol).new
-
-      migrator.before_apply do |_|
-        events.push :before
+        db.close
       end
-
-      migrator.after_apply do |_, _|
-        events.push :after
-      end
-
-      migrator.apply(1)
-      events.should eq([:before, :after])
-
-      db.close
-    end
-
-    it "does not trigger if migration is already applied" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-      fake_migration db, 1
-
-      count = 0
-      migrator.before_apply do |_|
-        count += 1
-      end
-
-      migrator.after_apply do |_, _|
-        count += 1
-      end
-
-      migrator.apply(1)
-      count.should eq(0)
-
-      db.close
-    end
-  end
-
-  describe "(rollback callback cycle)" do
-    it "triggers before a migration is rolled back" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-      fake_migration db, 1
-
-      count = 0
-      migrator.before_rollback do |_|
-        count += 1
-      end
-
-      migrator.rollback(1)
-      count.should eq(1)
-
-      db.close
-    end
-
-    it "triggers after a migration has been rolled back" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-      fake_migration db, 1
-
-      count = 0
-      migrator.after_rollback do |_, _|
-        count += 1
-      end
-
-      migrator.rollback(1)
-      count.should eq(1)
-
-      db.close
-    end
-
-    it "triggers callbacks in sequence" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-      fake_migration db, 1
-
-      events = Array(Symbol).new
-      migrator.before_rollback do |_|
-        events.push :before
-      end
-
-      migrator.after_rollback do |_, _|
-        events.push :after
-      end
-
-      migrator.rollback(1)
-      events.should eq([:before, :after])
-
-      db.close
-    end
-
-    it "does not trigger if migration is not applied" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-
-      count = 0
-      migrator.before_apply do |_|
-        count += 1
-      end
-
-      migrator.after_apply do |_, _|
-        count += 1
-      end
-
-      migrator.rollback(1)
-      count.should eq(0)
-
-      db.close
-    end
-
-    it "resets in the right order" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-      fake_migration db, 1, 1
-      fake_migration db, 3, 1
-      fake_migration db, 2, 2
-      fake_migration db, 4, 2
-
-      before_ids = Array(Int64).new
-      migrator.before_rollback do |id|
-        before_ids.push id
-      end
-
-      after_ids = Array(Int64).new
-      migrator.after_rollback do |id, _|
-        after_ids.push id
-      end
-
-      migrator.reset!
-      before_ids.size.should eq(4)
-      after_ids.size.should eq(4)
-      before_ids.should eq([4, 2, 3, 1])
-      after_ids.should eq([4, 2, 3, 1])
-
-      db.close
-    end
-  end
-
-  describe "#applied" do
-    it "returns an empty list when no migrations were applied" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-
-      migrator.applied.should be_empty
-
-      db.close
-    end
-
-    it "returns ordered list of applied migrations" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-      fake_migration db, 1
-      fake_migration db, 2
-
-      entries = migrator.applied
-      entries.should_not be_empty
-      entries.size.should eq(2)
-
-      mig1 = entries.first
-      mig1.id.should eq(1)
-
-      db.close
-    end
-
-    it "returns only known applied migrations" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-      fake_migration db, 2
-      fake_migration db, 5
-
-      entries = migrator.applied
-      entries.size.should eq(1)
-
-      mig2 = entries.first
-      mig2.id.should eq(2)
-
-      db.close
     end
   end
 end

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -26,7 +26,7 @@ private struct MigrationEntry
 end
 
 private def memory_db
-  DB.connect "sqlite3:%3Amemory%3A"
+  DB.open "sqlite3:%3Amemory%3A"
 end
 
 private def create_dummy(db)

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -16,6 +16,20 @@ require "../spec_helper"
 
 require "sqlite3"
 
+# Configuration for dialects to test
+DIALECTS = {
+  sqlite3: {
+    url: ENV["SQLITE3_DB_URL"]? || "sqlite3:%3Amemory%3A",
+    needs_cleanup: false,
+    skip: false,
+  },
+  postgresql: {
+    url: ENV["POSTGRES_DB_URL"]? || "postgres://drift:drift@localhost:5432/drift_test",
+    needs_cleanup: true,
+    skip: ENV["SKIP_POSTGRESQL"]? == "true",
+  },
+}
+
 private struct MigrationEntry
   include DB::Serializable
 
@@ -46,6 +60,11 @@ private def sample_context
   ctx.add Drift::Migration.new(4)
 
   ctx
+end
+
+private def cleanup_tables(db)
+  db.exec("DROP TABLE IF EXISTS drift_migrations CASCADE;")
+  db.exec("DROP TABLE IF EXISTS dummy CASCADE;")
 end
 
 private def ready_migrator(db = memory_db)

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -114,21 +114,27 @@ end
 describe Drift::Migrator do
   describe ".new" do
     it "reuses an existing context" do
+      db = memory_db
       ctx = sample_context
-      migrator = Drift::Migrator.new(memory_db, ctx)
+      migrator = Drift::Migrator.new(db, ctx)
 
       migrator.context.should be(ctx)
+
+      db.close
     end
   end
 
   describe ".from_path" do
     it "sets up a new context using a given path" do
-      migrator = Drift::Migrator.from_path(memory_db, fixture_path("sequence"))
+      db = memory_db
+      migrator = Drift::Migrator.from_path(db, fixture_path("sequence"))
 
       migrator.context.ids.should eq([
         20211219152312,
         20211220182717,
       ])
+
+      db.close
     end
   end
 

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -138,37 +138,49 @@ describe Drift::Migrator do
     end
   end
 
-  describe "#prepared?" do
-    it "returns false on an clean database" do
-      migrator = ready_migrator
+  for_each_dialect do
+    describe "#prepared?" do
+      it "returns false on an clean database" do
+        db = dialect_db.call
+        migrator = ready_migrator(db)
 
-      migrator.prepared?.should be_false
+        migrator.prepared?.should be_false
+
+        db.close
+      end
+
+      it "returns true on a prepared database" do
+        db = dialect_db.call
+        # dummy table
+        db.exec "CREATE TABLE drift_migrations (id INTEGER PRIMARY KEY, dummy TEXT);"
+        migrator = ready_migrator(db)
+
+        migrator.prepared?.should be_true
+
+        db.close
+      end
     end
 
-    it "returns true on a prepared database" do
-      db = memory_db
-      # dummy table
-      db.exec "CREATE TABLE drift_migrations (id INTEGER PRIMARY KEY, dummy TEXT);"
-      migrator = ready_migrator(db)
+    describe "#prepare!" do
+      it "prepares the migration table" do
+        db = dialect_db.call
+        migrator = ready_migrator(db)
 
-      migrator.prepared?.should be_true
-    end
-  end
+        migrator.prepare!
+        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
 
-  describe "#prepare!" do
-    it "prepares the migration table" do
-      db = memory_db
-      migrator = ready_migrator(db)
+        db.close
+      end
 
-      migrator.prepare!
-      db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
-    end
+      it "does noop if database is already prepared" do
+        db = dialect_db.call
+        migrator = ready_migrator(db)
 
-    it "does noop if database is already prepared" do
-      migrator = ready_migrator
+        migrator.prepare!
+        migrator.prepare!
 
-      migrator.prepare!
-      migrator.prepare!
+        db.close
+      end
     end
   end
 

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -718,7 +718,7 @@ describe Drift::Migrator do
           db.close
         end
 
-        it "excludes migraitons not locally available" do
+        it "excludes migrations not locally available" do
           db = dialect_db.call
           _, migrator = prepared_migrator(db)
           fake_migration db, 1

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -184,269 +184,277 @@ describe Drift::Migrator do
     end
   end
 
-  describe "#applied?" do
-    it "returns false when migration was not applied" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-
-      migrator.applied?(1).should be_false
-
-      db.close
-    end
-
-    it "returns true when migration was applied" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-      fake_migration db
-
-      migrator.applied?(1).should be_true
-
-      db.close
-    end
-  end
-
-  describe "#applied_ids" do
-    it "returns an empty list when no migrations were applied" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-
-      migrator.applied_ids.should be_empty
-
-      db.close
-    end
-
-    it "returns ordered list of applied migrations" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-      fake_migration db, 1
-      fake_migration db, 2
-
-      ids = migrator.applied_ids
-      ids.should_not be_empty
-      ids.should eq([1, 2])
-
-      db.close
-    end
-
-    it "returns only known applied migrations" do
-      db = memory_db
-      _, migrator = prepared_migrator(db)
-      fake_migration db, 1
-      fake_migration db, 5
-
-      ids = migrator.applied_ids
-      ids.should_not be_empty
-      ids.should eq([1])
-
-      db.close
-    end
-  end
-
-  describe "#apply_plan" do
-    context "with no migration applied" do
-      it "returns a list of all migrations" do
-        db = memory_db
+  for_each_dialect do
+    describe "#applied?" do
+      it "returns false when migration was not applied" do
+        db = dialect_db.call
         _, migrator = prepared_migrator(db)
 
-        ids = migrator.apply_plan
-        ids.should_not be_empty
-        ids.should eq([1, 2, 3, 4])
+        migrator.applied?(1).should be_false
+
+        db.close
+      end
+
+      it "returns true when migration was applied" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
+        fake_migration db
+
+        migrator.applied?(1).should be_true
 
         db.close
       end
     end
 
-    context "with some applied migrations" do
-      it "returns a list of non-applied migrations" do
-        db = memory_db
+    describe "#applied_ids" do
+      it "returns an empty list when no migrations were applied" do
+        db = dialect_db.call
+        _, migrator = prepared_migrator(db)
+
+        migrator.applied_ids.should be_empty
+
+        db.close
+      end
+
+      it "returns ordered list of applied migrations" do
+        db = dialect_db.call
         _, migrator = prepared_migrator(db)
         fake_migration db, 1
-        fake_migration db, 3
+        fake_migration db, 2
 
-        ids = migrator.apply_plan
+        ids = migrator.applied_ids
         ids.should_not be_empty
-        ids.should eq([2, 4])
+        ids.should eq([1, 2])
 
         db.close
       end
-    end
 
-    context "with applied migrations not locally available" do
-      it "returns the list of only local non-applied ones" do
-        db = memory_db
+      it "returns only known applied migrations" do
+        db = dialect_db.call
         _, migrator = prepared_migrator(db)
         fake_migration db, 1
         fake_migration db, 5
 
-        ids = migrator.apply_plan
-        ids.should eq([2, 3, 4])
+        ids = migrator.applied_ids
+        ids.should_not be_empty
+        ids.should eq([1])
 
         db.close
       end
     end
   end
 
-  describe "#apply(id)" do
-    context "with no existing migrations applied" do
-      it "records the migration was applied" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
+  for_each_dialect do
+    describe "#apply_plan" do
+      context "with no migration applied" do
+        it "returns a list of all migrations" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
 
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
-        migrator.apply(1)
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
+          ids = migrator.apply_plan
+          ids.should_not be_empty
+          ids.should eq([1, 2, 3, 4])
 
-        # id, batch, applied_at, duration_ns
-        result = db.query_one("SELECT id, batch, applied_at, duration_ns FROM drift_migrations WHERE id = ? LIMIT 1;", 1, as: MigrationEntry)
-
-        result.id.should eq(1)
-        result.batch.should eq(1)
-        result.applied_at.should be_close(Time.utc, 1.second)
-        result.duration_ns.should be <= 1.second.total_nanoseconds.to_i64
-
-        db.close
+          db.close
+        end
       end
 
-      it "applies migration only once" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        migrator.apply(1)
-        migrator.apply(1)
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
+      context "with some applied migrations" do
+        it "returns a list of non-applied migrations" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1
+          fake_migration db, 3
 
-        db.close
+          ids = migrator.apply_plan
+          ids.should_not be_empty
+          ids.should eq([2, 4])
+
+          db.close
+        end
       end
 
-      it "executes migration statements" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        create_dummy db
+      context "with applied migrations not locally available" do
+        it "returns the list of only local non-applied ones" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1
+          fake_migration db, 5
 
-        migration = migrator.context[1]
-        migration.add(:migrate, "INSERT INTO dummy (value) VALUES (10);")
+          ids = migrator.apply_plan
+          ids.should eq([2, 3, 4])
 
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-        migrator.apply(1)
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(1)
-        db.scalar("SELECT MAX(value) FROM dummy;").as(Int64).should eq(10)
-
-        db.close
+          db.close
+        end
       end
+    end
+  end
 
-      it "applies migration within a transaction to avoid partial execution" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        create_dummy db
+  for_each_dialect do
+    describe "#apply(id)" do
+      context "with no existing migrations applied" do
+        it "records the migration was applied" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
 
-        migration = migrator.context[1]
-        migration.add(:migrate, "INSERT INTO dummy (value) VALUES (10);")
-        migration.add(:migrate, "INSERT INTO foo (value)")
-
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-        expect_raises(Exception) do
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
           migrator.apply(1)
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
+
+          # id, batch, applied_at, duration_ns
+          result = db.query_one("SELECT id, batch, applied_at, duration_ns FROM drift_migrations WHERE id = ? LIMIT 1;", 1, as: MigrationEntry)
+
+          result.id.should eq(1)
+          result.batch.should eq(1)
+          result.applied_at.should be_close(Time.utc, 1.second)
+          result.duration_ns.should be <= 1.second.total_nanoseconds.to_i64
+
+          db.close
         end
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
 
-        db.close
+        it "applies migration only once" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          migrator.apply(1)
+          migrator.apply(1)
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
+
+          db.close
+        end
+
+        it "executes migration statements" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          create_dummy db
+
+          migration = migrator.context[1]
+          migration.add(:migrate, "INSERT INTO dummy (value) VALUES (10);")
+
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+          migrator.apply(1)
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(1)
+          db.scalar("SELECT MAX(value) FROM dummy;").as(Int64).should eq(10)
+
+          db.close
+        end
+
+        it "applies migration within a transaction to avoid partial execution" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          create_dummy db
+
+          migration = migrator.context[1]
+          migration.add(:migrate, "INSERT INTO dummy (value) VALUES (10);")
+          migration.add(:migrate, "INSERT INTO foo (value)")
+
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+          expect_raises(Exception) do
+            migrator.apply(1)
+          end
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+
+          db.close
+        end
       end
-    end
 
-    context "with existing migrations applied" do
-      it "applies other migration as a new batch" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        migrator.apply(1)
-        db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
+      context "with existing migrations applied" do
+        it "applies other migration as a new batch" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          migrator.apply(1)
+          db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
 
-        migrator.apply(2)
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
-        db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(2)
+          migrator.apply(2)
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
+          db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(2)
 
-        db.close
+          db.close
+        end
       end
     end
   end
 
-  describe "#apply(ids)" do
-    context "with no migrations" do
-      it "applies multiple migrations as part of the same batch" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
+  for_each_dialect do
+    describe "#apply(ids)" do
+      context "with no migrations" do
+        it "applies multiple migrations as part of the same batch" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
 
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
-        migrator.apply(1, 3)
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
-        db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
-
-        db.close
-      end
-
-      it "ignores already applied migration from the list" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db
-        create_dummy db
-
-        m1 = migrator.context[1]
-        m1.add(:migrate, "INSERT INTO dummy (value) VALUES (10);")
-
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
-        migrator.apply(1, 3)
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-
-        db.close
-      end
-
-      it "increases batch number when executed multiple times for new migrations" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
-        migrator.apply(1, 2)
-        db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
-        migrator.apply(3, 4)
-        db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(2)
-
-        db.close
-      end
-
-      it "applies all migrations as transaction to avoid partial execution" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        create_dummy db
-
-        m1 = migrator.context[1]
-        m1.add(:migrate, "INSERT INTO dummy (value) VALUES (10);")
-
-        m2 = migrator.context[3]
-        m2.add(:migrate, "INSERT INTO dummy (value) VALUES (20);")
-        m2.add(:migrate, "INSERT INTO foo (value)")
-
-        expect_raises(Exception) do
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
           migrator.apply(1, 3)
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
+          db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
+
+          db.close
         end
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
 
-        db.close
-      end
+        it "ignores already applied migration from the list" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db
+          create_dummy db
 
-      it "applies repeated migration in list only once" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        create_dummy db
+          m1 = migrator.context[1]
+          m1.add(:migrate, "INSERT INTO dummy (value) VALUES (10);")
 
-        migration = migrator.context[1]
-        migration.add(:migrate, "INSERT INTO dummy (value) VALUES (10);")
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
+          migrator.apply(1, 3)
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
 
-        migrator.apply(1, 1, 1)
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(1)
+          db.close
+        end
 
-        db.close
+        it "increases batch number when executed multiple times for new migrations" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+          migrator.apply(1, 2)
+          db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
+          migrator.apply(3, 4)
+          db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(2)
+
+          db.close
+        end
+
+        it "applies all migrations as transaction to avoid partial execution" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          create_dummy db
+
+          m1 = migrator.context[1]
+          m1.add(:migrate, "INSERT INTO dummy (value) VALUES (10);")
+
+          m2 = migrator.context[3]
+          m2.add(:migrate, "INSERT INTO dummy (value) VALUES (20);")
+          m2.add(:migrate, "INSERT INTO foo (value)")
+
+          expect_raises(Exception) do
+            migrator.apply(1, 3)
+          end
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+
+          db.close
+        end
+
+        it "applies repeated migration in list only once" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          create_dummy db
+
+          migration = migrator.context[1]
+          migration.add(:migrate, "INSERT INTO dummy (value) VALUES (10);")
+
+          migrator.apply(1, 1, 1)
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(1)
+
+          db.close
+        end
       end
     end
   end

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -459,165 +459,169 @@ describe Drift::Migrator do
     end
   end
 
-  describe "#rollback(id)" do
-    context "with migration applied" do
-      it "removes migration from the list of applied" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db
+  for_each_dialect do
+    describe "#rollback(id)" do
+      context "with migration applied" do
+        it "removes migration from the list of applied" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db
 
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
-        migrator.rollback(1)
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
-
-        db.close
-      end
-
-      it "executes migration down statements" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db
-        create_dummy db
-
-        migration = migrator.context[1]
-        migration.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
-
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-        migrator.rollback(1)
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(1)
-
-        db.close
-      end
-
-      it "removes only applied migrations" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db
-        create_dummy db
-
-        migration = migrator.context[2]
-        migration.add(:rollback, "INSERT INTO dummy (value) VALUES (20);")
-
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
-        migrator.rollback(2)
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-
-        db.close
-      end
-
-      it "applies rollback within a transaction to avoid partial execution" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db
-        create_dummy db
-
-        migration = migrator.context[1]
-        migration.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
-        migration.add(:rollback, "INSERT INTO foo (value)")
-
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-        expect_raises(Exception) do
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
           migrator.rollback(1)
-        end
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
 
-        db.close
+          db.close
+        end
+
+        it "executes migration down statements" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db
+          create_dummy db
+
+          migration = migrator.context[1]
+          migration.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
+
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+          migrator.rollback(1)
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(1)
+
+          db.close
+        end
+
+        it "removes only applied migrations" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db
+          create_dummy db
+
+          migration = migrator.context[2]
+          migration.add(:rollback, "INSERT INTO dummy (value) VALUES (20);")
+
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
+          migrator.rollback(2)
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+
+          db.close
+        end
+
+        it "applies rollback within a transaction to avoid partial execution" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db
+          create_dummy db
+
+          migration = migrator.context[1]
+          migration.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
+          migration.add(:rollback, "INSERT INTO foo (value)")
+
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+          expect_raises(Exception) do
+            migrator.rollback(1)
+          end
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
+
+          db.close
+        end
       end
     end
   end
 
-  describe "#rollback(ids)" do
-    context "with no migrations applied" do
-      it "does not rollback non-applied migration" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        create_dummy db
+  for_each_dialect do
+    describe "#rollback(ids)" do
+      context "with no migrations applied" do
+        it "does not rollback non-applied migration" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          create_dummy db
 
-        m1 = migrator.context[1]
-        m1.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
-        m3 = migrator.context[3]
-        m3.add(:rollback, "INSERT INTO dummy (value) VALUES (30);")
+          m1 = migrator.context[1]
+          m1.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
+          m3 = migrator.context[3]
+          m3.add(:rollback, "INSERT INTO dummy (value) VALUES (30);")
 
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-        migrator.rollback(3, 1)
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+          migrator.rollback(3, 1)
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
 
-        db.close
-      end
-    end
-
-    context "with migrations applied" do
-      it "removes migration from the list of applied" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db, 1
-        fake_migration db, 2
-
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
-        migrator.rollback(2, 1)
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
-
-        db.close
-      end
-
-      it "considers migration only once" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db, 1
-        create_dummy db
-
-        migration = migrator.context[1]
-        migration.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
-
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-        migrator.rollback(1, 1, 1, 1)
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(1)
-
-        db.close
-      end
-
-      it "executes migration down statements" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db, 1
-        fake_migration db, 2
-        create_dummy db
-
-        m1 = migrator.context[1]
-        m1.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
-        m2 = migrator.context[2]
-        m2.add(:rollback, "INSERT INTO dummy (value) VALUES (20);")
-
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-        migrator.rollback(2, 1)
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(2)
-        db.scalar("SELECT MAX(value) FROM dummy;").as(Int64).should eq(20)
-
-        db.close
-      end
-
-      it "applies rollback within a transaction to avoid partial execution" do
-        db = memory_db
-        _, migrator = prepared_migrator(db)
-        fake_migration db, 1
-        fake_migration db, 2
-        create_dummy db
-
-        m1 = migrator.context[1]
-        m1.add(:rollback, "INSERT INTO foo (value)")
-        m2 = migrator.context[2]
-        m2.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
-
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-        expect_raises(Exception) do
-          migrator.rollback(2, 1)
+          db.close
         end
-        db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
-        db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
+      end
 
-        db.close
+      context "with migrations applied" do
+        it "removes migration from the list of applied" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1
+          fake_migration db, 2
+
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
+          migrator.rollback(2, 1)
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+
+          db.close
+        end
+
+        it "considers migration only once" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1
+          create_dummy db
+
+          migration = migrator.context[1]
+          migration.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
+
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+          migrator.rollback(1, 1, 1, 1)
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(1)
+
+          db.close
+        end
+
+        it "executes migration down statements" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1
+          fake_migration db, 2
+          create_dummy db
+
+          m1 = migrator.context[1]
+          m1.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
+          m2 = migrator.context[2]
+          m2.add(:rollback, "INSERT INTO dummy (value) VALUES (20);")
+
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+          migrator.rollback(2, 1)
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(2)
+          db.scalar("SELECT MAX(value) FROM dummy;").as(Int64).should eq(20)
+
+          db.close
+        end
+
+        it "applies rollback within a transaction to avoid partial execution" do
+          db = dialect_db.call
+          _, migrator = prepared_migrator(db)
+          fake_migration db, 1
+          fake_migration db, 2
+          create_dummy db
+
+          m1 = migrator.context[1]
+          m1.add(:rollback, "INSERT INTO foo (value)")
+          m2 = migrator.context[2]
+          m2.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
+
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+          expect_raises(Exception) do
+            migrator.rollback(2, 1)
+          end
+          db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+          db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
+
+          db.close
+        end
       end
     end
   end

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -186,78 +186,102 @@ describe Drift::Migrator do
 
   describe "#applied?" do
     it "returns false when migration was not applied" do
-      _, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
 
       migrator.applied?(1).should be_false
+
+      db.close
     end
 
     it "returns true when migration was applied" do
-      db, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
       fake_migration db
 
       migrator.applied?(1).should be_true
+
+      db.close
     end
   end
 
   describe "#applied_ids" do
     it "returns an empty list when no migrations were applied" do
-      _, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
 
       migrator.applied_ids.should be_empty
+
+      db.close
     end
 
     it "returns ordered list of applied migrations" do
-      db, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
       fake_migration db, 1
       fake_migration db, 2
 
       ids = migrator.applied_ids
       ids.should_not be_empty
       ids.should eq([1, 2])
+
+      db.close
     end
 
     it "returns only known applied migrations" do
-      db, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
       fake_migration db, 1
       fake_migration db, 5
 
       ids = migrator.applied_ids
       ids.should_not be_empty
       ids.should eq([1])
+
+      db.close
     end
   end
 
   describe "#apply_plan" do
     context "with no migration applied" do
       it "returns a list of all migrations" do
-        _, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
 
         ids = migrator.apply_plan
         ids.should_not be_empty
         ids.should eq([1, 2, 3, 4])
+
+        db.close
       end
     end
 
     context "with some applied migrations" do
       it "returns a list of non-applied migrations" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1
         fake_migration db, 3
 
         ids = migrator.apply_plan
         ids.should_not be_empty
         ids.should eq([2, 4])
+
+        db.close
       end
     end
 
     context "with applied migrations not locally available" do
       it "returns the list of only local non-applied ones" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1
         fake_migration db, 5
 
         ids = migrator.apply_plan
         ids.should eq([2, 3, 4])
+
+        db.close
       end
     end
   end
@@ -265,7 +289,8 @@ describe Drift::Migrator do
   describe "#apply(id)" do
     context "with no existing migrations applied" do
       it "records the migration was applied" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
 
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
         migrator.apply(1)
@@ -278,17 +303,23 @@ describe Drift::Migrator do
         result.batch.should eq(1)
         result.applied_at.should be_close(Time.utc, 1.second)
         result.duration_ns.should be <= 1.second.total_nanoseconds.to_i64
+
+        db.close
       end
 
       it "applies migration only once" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         migrator.apply(1)
         migrator.apply(1)
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
+
+        db.close
       end
 
       it "executes migration statements" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         create_dummy db
 
         migration = migrator.context[1]
@@ -298,10 +329,13 @@ describe Drift::Migrator do
         migrator.apply(1)
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(1)
         db.scalar("SELECT MAX(value) FROM dummy;").as(Int64).should eq(10)
+
+        db.close
       end
 
       it "applies migration within a transaction to avoid partial execution" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         create_dummy db
 
         migration = migrator.context[1]
@@ -314,18 +348,23 @@ describe Drift::Migrator do
         end
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+
+        db.close
       end
     end
 
     context "with existing migrations applied" do
       it "applies other migration as a new batch" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         migrator.apply(1)
         db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
 
         migrator.apply(2)
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
         db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(2)
+
+        db.close
       end
     end
   end
@@ -333,16 +372,20 @@ describe Drift::Migrator do
   describe "#apply(ids)" do
     context "with no migrations" do
       it "applies multiple migrations as part of the same batch" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
 
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
         migrator.apply(1, 3)
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
         db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
+
+        db.close
       end
 
       it "ignores already applied migration from the list" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db
         create_dummy db
 
@@ -353,20 +396,26 @@ describe Drift::Migrator do
         migrator.apply(1, 3)
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+
+        db.close
       end
 
       it "increases batch number when executed multiple times for new migrations" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
 
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
         migrator.apply(1, 2)
         db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
         migrator.apply(3, 4)
         db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(2)
+
+        db.close
       end
 
       it "applies all migrations as transaction to avoid partial execution" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         create_dummy db
 
         m1 = migrator.context[1]
@@ -381,10 +430,13 @@ describe Drift::Migrator do
         end
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+
+        db.close
       end
 
       it "applies repeated migration in list only once" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         create_dummy db
 
         migration = migrator.context[1]
@@ -393,6 +445,8 @@ describe Drift::Migrator do
         migrator.apply(1, 1, 1)
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(1)
+
+        db.close
       end
     end
   end
@@ -400,16 +454,20 @@ describe Drift::Migrator do
   describe "#rollback(id)" do
     context "with migration applied" do
       it "removes migration from the list of applied" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db
 
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
         migrator.rollback(1)
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+
+        db.close
       end
 
       it "executes migration down statements" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db
         create_dummy db
 
@@ -419,10 +477,13 @@ describe Drift::Migrator do
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
         migrator.rollback(1)
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(1)
+
+        db.close
       end
 
       it "removes only applied migrations" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db
         create_dummy db
 
@@ -433,10 +494,13 @@ describe Drift::Migrator do
         migrator.rollback(2)
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+
+        db.close
       end
 
       it "applies rollback within a transaction to avoid partial execution" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db
         create_dummy db
 
@@ -450,6 +514,8 @@ describe Drift::Migrator do
         end
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
+
+        db.close
       end
     end
   end
@@ -457,7 +523,8 @@ describe Drift::Migrator do
   describe "#rollback(ids)" do
     context "with no migrations applied" do
       it "does not rollback non-applied migration" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         create_dummy db
 
         m1 = migrator.context[1]
@@ -468,22 +535,28 @@ describe Drift::Migrator do
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
         migrator.rollback(3, 1)
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
+
+        db.close
       end
     end
 
     context "with migrations applied" do
       it "removes migration from the list of applied" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1
         fake_migration db, 2
 
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
         migrator.rollback(2, 1)
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+
+        db.close
       end
 
       it "considers migration only once" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1
         create_dummy db
 
@@ -493,10 +566,13 @@ describe Drift::Migrator do
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
         migrator.rollback(1, 1, 1, 1)
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(1)
+
+        db.close
       end
 
       it "executes migration down statements" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1
         fake_migration db, 2
         create_dummy db
@@ -510,10 +586,13 @@ describe Drift::Migrator do
         migrator.rollback(2, 1)
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(2)
         db.scalar("SELECT MAX(value) FROM dummy;").as(Int64).should eq(20)
+
+        db.close
       end
 
       it "applies rollback within a transaction to avoid partial execution" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1
         fake_migration db, 2
         create_dummy db
@@ -529,6 +608,8 @@ describe Drift::Migrator do
         end
         db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(2)
+
+        db.close
       end
     end
   end
@@ -536,26 +617,33 @@ describe Drift::Migrator do
   describe "#rollback_plan" do
     context "with no migration applied" do
       it "returns an empty list of migrations" do
-        _, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
 
         ids = migrator.rollback_plan
         ids.should be_empty
+
+        db.close
       end
     end
 
     context "dealing with batches" do
       it "returns the list of migrations in reverse order" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1
         fake_migration db, 2
 
         ids = migrator.rollback_plan
         ids.should_not be_empty
         ids.should eq([2, 1])
+
+        db.close
       end
 
       it "returns only the list of migrations in the last batch" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1, 1
         fake_migration db, 2, 1
         fake_migration db, 4, 2
@@ -563,16 +651,21 @@ describe Drift::Migrator do
         ids = migrator.rollback_plan
         ids.should_not be_empty
         ids.should eq([4])
+
+        db.close
       end
     end
 
     context "migrations not available locally" do
       it "excludes migrations not locally available" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 5
 
         ids = migrator.rollback_plan
         ids.should be_empty
+
+        db.close
       end
     end
   end
@@ -580,38 +673,48 @@ describe Drift::Migrator do
   describe "#reset_plan" do
     context "with no migration applied" do
       it "returns an empty list of migrations" do
-        _, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
 
         ids = migrator.reset_plan
         ids.should be_empty
+
+        db.close
       end
     end
 
     context "with a single batch" do
       it "returns a list of migrations in reverse order" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1
         fake_migration db, 3
 
         ids = migrator.reset_plan
         ids.should_not be_empty
         ids.should eq([3, 1])
+
+        db.close
       end
 
       it "excludes migraitons not locally available" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1
         fake_migration db, 5
 
         ids = migrator.reset_plan
         ids.should_not be_empty
         ids.should eq([1])
+
+        db.close
       end
     end
 
     context "with multiple batches" do
       it "returns list of migrations in reverse order" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1, 1
         fake_migration db, 3, 1
         fake_migration db, 2, 2
@@ -620,25 +723,33 @@ describe Drift::Migrator do
         ids = migrator.reset_plan
         ids.should_not be_empty
         ids.should eq([4, 2, 3, 1])
+
+        db.close
       end
     end
   end
 
   describe "#pending?" do
     it "returns true when no migration was applied" do
-      _, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
 
       migrator.pending?.should be_true
+
+      db.close
     end
 
     it "returns false when all migrations were applied" do
-      db, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
       fake_migration db, 1
       fake_migration db, 2
       fake_migration db, 3
       fake_migration db, 4
 
       migrator.pending?.should be_false
+
+      db.close
     end
   end
 
@@ -650,23 +761,29 @@ describe Drift::Migrator do
 
         migrator.apply!
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(4)
+
+        db.close
       end
     end
 
     context "with no existing migration applied" do
       it "applies all available migrations as single batch" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
 
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
         migrator.apply!
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(4)
         db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(1)
+
+        db.close
       end
     end
 
     context "with existing batches" do
       it "applies pending migrations as new batch" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1
         fake_migration db, 3
 
@@ -674,6 +791,8 @@ describe Drift::Migrator do
         migrator.apply!
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(4)
         db.scalar("SELECT MAX(batch) FROM drift_migrations;").as(Int64).should eq(2)
+
+        db.close
       end
     end
   end
@@ -681,29 +800,36 @@ describe Drift::Migrator do
   describe "#reset!" do
     context "with no migration applied" do
       it "does nothing" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
 
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
         migrator.reset!
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+
+        db.close
       end
     end
 
     context "with some applied migrations" do
       it "resets the migration status" do
-        db, migrator = prepared_migrator
+        db = memory_db
+        _, migrator = prepared_migrator(db)
         fake_migration db, 1
         fake_migration db, 3
 
         migrator.reset!
         db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(0)
+
+        db.close
       end
     end
   end
 
   describe "(apply callback cycle)" do
     it "triggers before a migration is applied" do
-      _, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
 
       count = 0
       migrator.before_apply do |_|
@@ -712,10 +838,13 @@ describe Drift::Migrator do
 
       migrator.apply(1)
       count.should eq(1)
+
+      db.close
     end
 
     it "triggers after a migration has been applied" do
-      _, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
 
       count = 0
       migrator.after_apply do |_, _|
@@ -724,10 +853,13 @@ describe Drift::Migrator do
 
       migrator.apply(1)
       count.should eq(1)
+
+      db.close
     end
 
     it "triggers callbacks in sequence" do
-      _, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
 
       events = Array(Symbol).new
 
@@ -741,10 +873,13 @@ describe Drift::Migrator do
 
       migrator.apply(1)
       events.should eq([:before, :after])
+
+      db.close
     end
 
     it "does not trigger if migration is already applied" do
-      db, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
       fake_migration db, 1
 
       count = 0
@@ -758,12 +893,15 @@ describe Drift::Migrator do
 
       migrator.apply(1)
       count.should eq(0)
+
+      db.close
     end
   end
 
   describe "(rollback callback cycle)" do
     it "triggers before a migration is rolled back" do
-      db, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
       fake_migration db, 1
 
       count = 0
@@ -773,10 +911,13 @@ describe Drift::Migrator do
 
       migrator.rollback(1)
       count.should eq(1)
+
+      db.close
     end
 
     it "triggers after a migration has been rolled back" do
-      db, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
       fake_migration db, 1
 
       count = 0
@@ -786,10 +927,13 @@ describe Drift::Migrator do
 
       migrator.rollback(1)
       count.should eq(1)
+
+      db.close
     end
 
     it "triggers callbacks in sequence" do
-      db, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
       fake_migration db, 1
 
       events = Array(Symbol).new
@@ -803,10 +947,13 @@ describe Drift::Migrator do
 
       migrator.rollback(1)
       events.should eq([:before, :after])
+
+      db.close
     end
 
     it "does not trigger if migration is not applied" do
-      _, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
 
       count = 0
       migrator.before_apply do |_|
@@ -819,10 +966,13 @@ describe Drift::Migrator do
 
       migrator.rollback(1)
       count.should eq(0)
+
+      db.close
     end
 
     it "resets in the right order" do
-      db, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
       fake_migration db, 1, 1
       fake_migration db, 3, 1
       fake_migration db, 2, 2
@@ -843,18 +993,24 @@ describe Drift::Migrator do
       after_ids.size.should eq(4)
       before_ids.should eq([4, 2, 3, 1])
       after_ids.should eq([4, 2, 3, 1])
+
+      db.close
     end
   end
 
   describe "#applied" do
     it "returns an empty list when no migrations were applied" do
-      _, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
 
       migrator.applied.should be_empty
+
+      db.close
     end
 
     it "returns ordered list of applied migrations" do
-      db, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
       fake_migration db, 1
       fake_migration db, 2
 
@@ -864,10 +1020,13 @@ describe Drift::Migrator do
 
       mig1 = entries.first
       mig1.id.should eq(1)
+
+      db.close
     end
 
     it "returns only known applied migrations" do
-      db, migrator = prepared_migrator
+      db = memory_db
+      _, migrator = prepared_migrator(db)
       fake_migration db, 2
       fake_migration db, 5
 
@@ -876,6 +1035,8 @@ describe Drift::Migrator do
 
       mig2 = entries.first
       mig2.id.should eq(2)
+
+      db.close
     end
   end
 end

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -302,7 +302,7 @@ describe Drift::Migrator do
           db.scalar("SELECT COUNT(id) FROM drift_migrations;").as(Int64).should eq(1)
 
           # id, batch, applied_at, duration_ns
-          result = db.query_one("SELECT id, batch, applied_at, duration_ns FROM drift_migrations WHERE id = ? LIMIT 1;", 1, as: MigrationEntry)
+          result = db.query_one("SELECT id, batch, applied_at, duration_ns FROM drift_migrations ORDER BY id ASC LIMIT 1;", as: MigrationEntry)
 
           result.id.should eq(1)
           result.batch.should eq(1)
@@ -345,7 +345,7 @@ describe Drift::Migrator do
 
           migration = migrator.context[1]
           migration.add(:migrate, "INSERT INTO dummy (value) VALUES (10);")
-          migration.add(:migrate, "INSERT INTO foo (value)")
+          migration.add(:migrate, "INSERT INTO foo (value);")
 
           db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
           expect_raises(Exception) do
@@ -515,7 +515,7 @@ describe Drift::Migrator do
 
           migration = migrator.context[1]
           migration.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
-          migration.add(:rollback, "INSERT INTO foo (value)")
+          migration.add(:rollback, "INSERT INTO foo (value);")
 
           db.scalar("SELECT COUNT(id) FROM dummy;").as(Int64).should eq(0)
           expect_raises(Exception) do
@@ -609,7 +609,7 @@ describe Drift::Migrator do
           create_dummy db
 
           m1 = migrator.context[1]
-          m1.add(:rollback, "INSERT INTO foo (value)")
+          m1.add(:rollback, "INSERT INTO foo (value);")
           m2 = migrator.context[2]
           m2.add(:rollback, "INSERT INTO dummy (value) VALUES (10);")
 

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -44,11 +44,21 @@ private def memory_db
 end
 
 private def create_dummy(db)
-  db.exec("CREATE TABLE IF NOT EXISTS dummy (id INTEGER PRIMARY KEY NOT NULL, value INTEGER NOT NULL);")
+  case Drift::Dialect.from_db(db)
+  when Drift::Dialect::SQLite3
+    db.exec("CREATE TABLE IF NOT EXISTS dummy (id INTEGER PRIMARY KEY NOT NULL, value INTEGER NOT NULL);")
+  when Drift::Dialect::PostgreSQL
+    db.exec("CREATE TABLE IF NOT EXISTS dummy (id BIGSERIAL PRIMARY KEY NOT NULL, value BIGINT NOT NULL);")
+  end
 end
 
 private def fake_migration(db, id = 1, batch = 1)
-  db.exec("INSERT INTO drift_migrations (id, batch, applied_at, duration_ns) VALUES (?, ?, ?, ?);", id, batch, Time.utc, 100000)
+  case Drift::Dialect.from_db(db)
+  when Drift::Dialect::SQLite3
+    db.exec("INSERT INTO drift_migrations (id, batch, applied_at, duration_ns) VALUES (?, ?, ?, ?);", id, batch, Time.utc, 100000)
+  when Drift::Dialect::PostgreSQL
+    db.exec("INSERT INTO drift_migrations (id, batch, applied_at, duration_ns) VALUES ($1, $2, $3, $4);", id, batch, Time.utc, 100000)
+  end
 end
 
 private def sample_context
@@ -67,15 +77,14 @@ private def cleanup_tables(db)
   db.exec("DROP TABLE IF EXISTS dummy CASCADE;")
 end
 
-private def ready_migrator(db = memory_db)
+private def ready_migrator(db)
   ctx = sample_context
   migrator = Drift::Migrator.new(db, ctx)
 
   migrator
 end
 
-private def prepared_migrator
-  db = memory_db
+private def prepared_migrator(db)
   migrator = ready_migrator(db)
   migrator.prepare!
 

--- a/spec/drift/migrator_spec.cr
+++ b/spec/drift/migrator_spec.cr
@@ -82,6 +82,26 @@ private def prepared_migrator
   {db, migrator}
 end
 
+# Macro to run tests for each dialect
+macro for_each_dialect
+  {% for name, config in DIALECTS %}
+    {% unless config[:skip] %}
+      describe "with {{ name.id }}" do
+        # Proc to get a clean DB connection for this dialect
+        dialect_db = ->() {
+          db = DB.open({{ config[:url] }})
+          {% if config[:needs_cleanup] %}
+            cleanup_tables(db)
+          {% end %}
+          db
+        }
+
+        {{ yield }}
+      end
+    {% end %}
+  {% end %}
+end
+
 describe Drift::Migrator do
   describe ".new" do
     it "reuses an existing context" do

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -17,6 +17,7 @@ require "option_parser"
 require "./drift"
 require "./drift/commands/*"
 
+require "pg"
 require "sqlite3"
 
 module Drift

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -17,6 +17,7 @@ require "option_parser"
 require "./drift"
 require "./drift/commands/*"
 
+require "mysql"
 require "pg"
 require "sqlite3"
 

--- a/src/drift/dialect.cr
+++ b/src/drift/dialect.cr
@@ -36,6 +36,8 @@ module Drift
       case conn.class.name
       when .starts_with?("SQLite3")
         SQLite3.new
+      when .starts_with?("PG::")
+        PostgreSQL.new
       else
         raise UnsupportedDialectError.new("Unsupported database: #{conn.class.name}")
       end

--- a/src/drift/dialect.cr
+++ b/src/drift/dialect.cr
@@ -34,10 +34,12 @@ module Drift
     # :ditto:
     def self.from_db(conn : DB::Connection) : Dialect
       case conn.class.name
-      when .starts_with?("SQLite3")
-        SQLite3.new
+      when .starts_with?("MySQL::")
+        MySQL.new
       when .starts_with?("PG::")
         PostgreSQL.new
+      when .starts_with?("SQLite3")
+        SQLite3.new
       else
         raise UnsupportedDialectError.new("Unsupported database: #{conn.class.name}")
       end

--- a/src/drift/dialect.cr
+++ b/src/drift/dialect.cr
@@ -34,7 +34,7 @@ module Drift
     # :ditto:
     def self.from_db(conn : DB::Connection) : Dialect
       case conn.class.name
-      when .starts_with?("MySQL::")
+      when .starts_with?("MySql::")
         MySQL.new
       when .starts_with?("PG::")
         PostgreSQL.new

--- a/src/drift/dialect.cr
+++ b/src/drift/dialect.cr
@@ -147,6 +147,14 @@ module Drift
       db.using_connection { |conn| max_batch(conn) }
     end
 
+    # Retrieve migration IDs for a specific batch in reverse order (id DESC)
+    abstract def batch_migration_ids_reverse(conn : DB::Connection, batch : Int64) : Array(Int64)
+
+    # :ditto:
+    def batch_migration_ids_reverse(db : DB::Database, batch : Int64) : Array(Int64)
+      db.using_connection { |conn| batch_migration_ids_reverse(conn, batch) }
+    end
+
     # Insert a new migration record into the tracking table
     abstract def insert_migration(conn : DB::Connection, id : Int64, batch : Int64, applied_at : Time, duration_ns : Int64) : Nil
 

--- a/src/drift/dialect.cr
+++ b/src/drift/dialect.cr
@@ -1,0 +1,168 @@
+# Copyright 2025 Luis Lavena
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "db"
+
+module Drift
+  # Raised when an unsupported database dialect is detected
+  class UnsupportedDialectError < Error
+  end
+
+  # Abstract interface for database-specific SQL operations
+  #
+  # Each dialect handles the SQL generation and execution for its specific
+  # database engine (SQLite3, PostgreSQL, MySQL, etc.)
+  abstract struct Dialect
+    # Detects the appropriate dialect from a database connection
+    def self.from_db(db : DB::Database) : Dialect
+      db.using_connection do |conn|
+        return from_db(conn)
+      end
+    end
+
+    # :ditto:
+    def self.from_db(conn : DB::Connection) : Dialect
+      case conn.class.name
+      when .starts_with?("SQLite3")
+        SQLite3.new
+      else
+        raise UnsupportedDialectError.new("Unsupported database: #{conn.class.name}")
+      end
+    end
+
+    # Check if the migrations table exists in the database
+    abstract def prepared?(conn : DB::Connection) : Bool
+
+    # :ditto:
+    def prepared?(db : DB::Database) : Bool
+      db.using_connection { |conn| prepared?(conn) }
+    end
+
+    # Create the migrations tracking table
+    abstract def create_schema!(conn : DB::Connection) : Nil
+
+    # :ditto:
+    def create_schema!(db : DB::Database) : Nil
+      db.using_connection { |conn| create_schema!(conn) }
+    end
+
+    # Find a specific migration by *id*, returns the ID if found, nil otherwise
+    abstract def find_migration_id(conn : DB::Connection, id : Int64) : Int64?
+
+    # :ditto:
+    def find_migration_id(db : DB::Database, id : Int64) : Int64?
+      db.using_connection { |conn| find_migration_id(conn, id) }
+    end
+
+    # Retrieve all migration IDs from the tracking table
+    def all_migration_ids(conn : DB::Connection) : Array(Int64)
+      sql_applied_ids = <<-SQL
+        SELECT
+          id
+        FROM
+          drift_migrations
+        ORDER BY
+          id ASC;
+        SQL
+
+      conn.query_all(sql_applied_ids, as: Int64)
+    end
+
+    # :ditto:
+    def all_migration_ids(db : DB::Database) : Array(Int64)
+      db.using_connection { |conn| all_migration_ids(conn) }
+    end
+
+    # Retrieve all migration IDs in reverse order (batch DESC, id DESC) for
+    # reset planning.
+    def all_migration_ids_reverse(conn : DB::Connection) : Array(Int64)
+      sql_reverse_applied_plan = <<-SQL
+        SELECT
+          id
+        FROM
+          drift_migrations
+        ORDER BY
+          batch DESC,
+          id DESC;
+        SQL
+
+      conn.query_all(sql_reverse_applied_plan, as: Int64)
+    end
+
+    # :ditto:
+    def all_migration_ids_reverse(db : DB::Database) : Array(Int64)
+      db.using_connection { |conn| all_migration_ids_reverse(conn) }
+    end
+
+    # Retrieve all migration entries with full metadata
+    def all_migrations(conn : DB::Connection) : Array(Migrator::MigrationEntry)
+      sql_all_applied = <<-SQL
+        SELECT
+          id, batch, applied_at, duration_ns
+        FROM
+          drift_migrations
+        ORDER BY
+          id ASC;
+        SQL
+
+      conn.query_all(sql_all_applied, as: Migrator::MigrationEntry)
+    end
+
+    # :ditto:
+    def all_migrations(db : DB::Database) : Array(Migrator::MigrationEntry)
+      db.using_connection { |conn| all_migrations(conn) }
+    end
+
+    # Get the maximum batch number from the tracking table, or zero if no batch
+    # exists
+    def max_batch(conn : DB::Connection) : Int64
+      sql_last_batch = <<-SQL
+        SELECT
+          COALESCE(
+            MAX(batch),
+            0
+          )
+        FROM
+          drift_migrations
+        LIMIT
+          1;
+        SQL
+
+      conn.query_one(sql_last_batch, as: Int64)
+    end
+
+    # :ditto:
+    def max_batch(db : DB::Database) : Int64
+      db.using_connection { |conn| max_batch(conn) }
+    end
+
+    # Insert a new migration record into the tracking table
+    abstract def insert_migration(conn : DB::Connection, id : Int64, batch : Int64, applied_at : Time, duration_ns : Int64) : Nil
+
+    # :ditto:
+    def insert_migration(db : DB::Database, id : Int64, batch : Int64, applied_at : Time, duration_ns : Int64) : Nil
+      db.using_connection { |conn| insert_migration(conn, id, batch, applied_at, duration_ns) }
+    end
+
+    # Delete a migration record *id* from the tracking table
+    abstract def delete_migration(conn : DB::Connection, id : Int64) : Nil
+
+    # :ditto:
+    def delete_migration(db : DB::Database, id : Int64) : Nil
+      db.using_connection { |conn| delete_migration(conn, id) }
+    end
+  end
+end
+
+require "./dialect/*"

--- a/src/drift/dialect/mysql.cr
+++ b/src/drift/dialect/mysql.cr
@@ -37,12 +37,30 @@ module Drift
           CREATE TABLE IF NOT EXISTS drift_migrations (
             id BIGINT PRIMARY KEY NOT NULL,
             batch BIGINT NOT NULL,
-            applied_at TIMESTAMP NOT NULL,
+            applied_at DATETIME NOT NULL,
             duration_ns BIGINT NOT NULL
           );
           SQL
 
+        sql_check_index = <<-SQL
+          SELECT
+            COUNT(*)
+          FROM
+            INFORMATION_SCHEMA.STATISTICS
+          WHERE
+            TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME = 'drift_migrations'
+            AND INDEX_NAME = 'idx_drift_migrations_batch';
+          SQL
+
+        sql_create_index = <<-SQL
+          CREATE INDEX idx_drift_migrations_batch ON drift_migrations(batch);
+          SQL
+
         conn.exec(sql_create_schema)
+        if conn.query_one(sql_check_index, as: Int64) == 0
+          conn.exec(sql_create_index)
+        end
       end
 
       def find_migration_id(conn : DB::Connection, id : Int64) : Int64?

--- a/src/drift/dialect/mysql.cr
+++ b/src/drift/dialect/mysql.cr
@@ -1,0 +1,101 @@
+# Copyright 2025 Luis Lavena
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Drift
+  struct Dialect
+    # MySQL implementation
+    struct MySQL < Dialect
+      def prepared?(conn : DB::Connection) : Bool
+        sql_check_schema = <<-SQL
+          SELECT
+            TABLE_NAME
+          FROM
+            INFORMATION_SCHEMA.TABLES
+          WHERE
+            TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME = 'drift_migrations'
+          LIMIT
+            1;
+          SQL
+
+        conn.query_one?(sql_check_schema, as: String) ? true : false
+      end
+
+      def create_schema!(conn : DB::Connection) : Nil
+        sql_create_schema = <<-SQL
+          CREATE TABLE IF NOT EXISTS drift_migrations (
+            id BIGINT PRIMARY KEY NOT NULL,
+            batch BIGINT NOT NULL,
+            applied_at TIMESTAMP NOT NULL,
+            duration_ns BIGINT NOT NULL
+          );
+          SQL
+
+        conn.exec(sql_create_schema)
+      end
+
+      def find_migration_id(conn : DB::Connection, id : Int64) : Int64?
+        sql_find_migration_id = <<-SQL
+          SELECT
+            id
+          FROM
+            drift_migrations
+          WHERE
+            id = ?
+          LIMIT
+            1;
+          SQL
+
+        conn.query_one?(sql_find_migration_id, id, as: Int64)
+      end
+
+      def batch_migration_ids_reverse(conn : DB::Connection, batch : Int64) : Array(Int64)
+        sql_batch_ids_reverse = <<-SQL
+          SELECT
+            id
+          FROM
+            drift_migrations
+          WHERE
+            batch = ?
+          ORDER BY
+            id DESC;
+          SQL
+
+        conn.query_all(sql_batch_ids_reverse, batch, as: Int64)
+      end
+
+      def insert_migration(conn : DB::Connection, id : Int64, batch : Int64, applied_at : Time, duration_ns : Int64) : Nil
+        sql_insert_migration = <<-SQL
+          INSERT INTO drift_migrations
+            (id, batch, applied_at, duration_ns)
+          VALUES
+            (?, ?, ?, ?);
+          SQL
+
+        conn.exec(sql_insert_migration, id, batch, applied_at, duration_ns)
+      end
+
+      def delete_migration(conn : DB::Connection, id : Int64) : Nil
+        sql_delete_migration = <<-SQL
+          DELETE FROM
+            drift_migrations
+          WHERE
+            id = ?;
+          SQL
+
+        conn.exec(sql_delete_migration, id)
+      end
+    end
+  end
+end

--- a/src/drift/dialect/postgresql.cr
+++ b/src/drift/dialect/postgresql.cr
@@ -1,0 +1,101 @@
+# Copyright 2025 Luis Lavena
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Drift
+  struct Dialect
+    # PostgreSQL implementation
+    struct PostgreSQL < Dialect
+      def prepared?(conn : DB::Connection) : Bool
+        sql_check_schema = <<-SQL
+          SELECT
+            tablename
+          FROM
+            pg_tables
+          WHERE
+            schemaname = 'public'
+            AND tablename = 'drift_migrations'
+          LIMIT
+            1;
+          SQL
+
+        conn.query_one?(sql_check_schema, as: String) ? true : false
+      end
+
+      def create_schema!(conn : DB::Connection) : Nil
+        sql_create_schema = <<-SQL
+          CREATE TABLE IF NOT EXISTS drift_migrations (
+            id BIGINT PRIMARY KEY NOT NULL,
+            batch BIGINT NOT NULL,
+            applied_at TIMESTAMP WITH TIME ZONE NOT NULL,
+            duration_ns BIGINT NOT NULL
+          );
+          SQL
+
+        conn.exec(sql_create_schema)
+      end
+
+      def find_migration_id(conn : DB::Connection, id : Int64) : Int64?
+        sql_find_migration_id = <<-SQL
+          SELECT
+            id
+          FROM
+            drift_migrations
+          WHERE
+            id = $1
+          LIMIT
+            1;
+          SQL
+
+        conn.query_one?(sql_find_migration_id, id, as: Int64)
+      end
+
+      def batch_migration_ids_reverse(conn : DB::Connection, batch : Int64) : Array(Int64)
+        sql_batch_ids_reverse = <<-SQL
+          SELECT
+            id
+          FROM
+            drift_migrations
+          WHERE
+            batch = $1
+          ORDER BY
+            id DESC;
+          SQL
+
+        conn.query_all(sql_batch_ids_reverse, batch, as: Int64)
+      end
+
+      def insert_migration(conn : DB::Connection, id : Int64, batch : Int64, applied_at : Time, duration_ns : Int64) : Nil
+        sql_insert_migration = <<-SQL
+          INSERT INTO drift_migrations
+            (id, batch, applied_at, duration_ns)
+          VALUES
+            ($1, $2, $3, $4);
+          SQL
+
+        conn.exec(sql_insert_migration, id, batch, applied_at, duration_ns)
+      end
+
+      def delete_migration(conn : DB::Connection, id : Int64) : Nil
+        sql_delete_migration = <<-SQL
+          DELETE FROM
+            drift_migrations
+          WHERE
+            id = $1;
+          SQL
+
+        conn.exec(sql_delete_migration, id)
+      end
+    end
+  end
+end

--- a/src/drift/dialect/postgresql.cr
+++ b/src/drift/dialect/postgresql.cr
@@ -42,7 +42,12 @@ module Drift
           );
           SQL
 
+        sql_create_index = <<-SQL
+          CREATE INDEX IF NOT EXISTS idx_drift_migrations_batch ON drift_migrations(batch);
+          SQL
+
         conn.exec(sql_create_schema)
+        conn.exec(sql_create_index)
       end
 
       def find_migration_id(conn : DB::Connection, id : Int64) : Int64?

--- a/src/drift/dialect/sqlite3.cr
+++ b/src/drift/dialect/sqlite3.cr
@@ -1,0 +1,86 @@
+# Copyright 2025 Luis Lavena
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Drift
+  struct Dialect
+    # SQLite3-compatible SQL implementation
+    struct SQLite3 < Dialect
+      def prepared?(conn : DB::Connection) : Bool
+        sql_check_schema = <<-SQL
+          SELECT
+            name
+          FROM
+            sqlite_schema
+          WHERE
+            type = "table"
+            AND name = "drift_migrations"
+          LIMIT
+            1;
+          SQL
+
+        conn.query_one?(sql_check_schema, as: String) ? true : false
+      end
+
+      def create_schema!(conn : DB::Connection) : Nil
+        sql_create_schema = <<-SQL
+          CREATE TABLE IF NOT EXISTS drift_migrations (
+            id INTEGER PRIMARY KEY NOT NULL,
+            batch INTEGER NOT NULL,
+            applied_at TEXT NOT NULL,
+            duration_ns INTEGER NOT NULL
+          );
+          SQL
+
+        conn.exec(sql_create_schema)
+      end
+
+      def find_migration_id(conn : DB::Connection, id : Int64) : Int64?
+        sql_find_migration_id = <<-SQL
+          SELECT
+            id
+          FROM
+            drift_migrations
+          WHERE
+            id = ?
+          LIMIT
+            1;
+          SQL
+
+        conn.query_one?(sql_find_migration_id, id, as: Int64)
+      end
+
+      def insert_migration(conn : DB::Connection, id : Int64, batch : Int64, applied_at : Time, duration_ns : Int64) : Nil
+        sql_insert_migration = <<-SQL
+          INSERT INTO drift_migrations
+            (id, batch, applied_at, duration_ns)
+          VALUES
+            (?, ?, ?, ?);
+          SQL
+
+        conn.exec(sql_insert_migration, id, batch, applied_at, duration_ns)
+      end
+
+      def delete_migration(conn : DB::Connection, id : Int64) : Nil
+        sql_delete_migration = <<-SQL
+          DELETE FROM
+            drift_migrations
+          WHERE
+            id = ?;
+          SQL
+
+        conn.exec(sql_delete_migration, id)
+      end
+    end
+  end
+end

--- a/src/drift/dialect/sqlite3.cr
+++ b/src/drift/dialect/sqlite3.cr
@@ -42,7 +42,12 @@ module Drift
           );
           SQL
 
+        sql_create_index = <<-SQL
+          CREATE INDEX IF NOT EXISTS idx_drift_migrations_batch ON drift_migrations(batch);
+          SQL
+
         conn.exec(sql_create_schema)
+        conn.exec(sql_create_index)
       end
 
       def find_migration_id(conn : DB::Connection, id : Int64) : Int64?

--- a/src/drift/dialect/sqlite3.cr
+++ b/src/drift/dialect/sqlite3.cr
@@ -60,6 +60,21 @@ module Drift
         conn.query_one?(sql_find_migration_id, id, as: Int64)
       end
 
+      def batch_migration_ids_reverse(conn : DB::Connection, batch : Int64) : Array(Int64)
+        sql_batch_ids_reverse = <<-SQL
+          SELECT
+            id
+          FROM
+            drift_migrations
+          WHERE
+            batch = ?
+          ORDER BY
+            id DESC;
+          SQL
+
+        conn.query_all(sql_batch_ids_reverse, batch, as: Int64)
+      end
+
       def insert_migration(conn : DB::Connection, id : Int64, batch : Int64, applied_at : Time, duration_ns : Int64) : Nil
         sql_insert_migration = <<-SQL
           INSERT INTO drift_migrations

--- a/src/drift/migrator.cr
+++ b/src/drift/migrator.cr
@@ -15,6 +15,8 @@
 require "./context"
 require "db"
 
+require "./dialect"
+
 module Drift
   class Migrator
     class MigrationEntry
@@ -42,7 +44,10 @@ module Drift
     @before_rollback = Array(BeforeCallback).new
     @after_rollback = Array(AfterCallback).new
 
+    @dialect : Dialect
+
     def initialize(@db, @context)
+      @dialect = Dialect.from_db(@db)
     end
 
     def self.from_path(db, path : String)
@@ -61,49 +66,20 @@ module Drift
     end
 
     def applied : Array(MigrationEntry)
-      sql_all_applied = <<-SQL
-        SELECT
-          id, batch, applied_at, duration_ns
-        FROM
-          drift_migrations
-        ORDER BY
-          id ASC;
-        SQL
-
-      entries = db.query_all(sql_all_applied, as: MigrationEntry)
+      entries = @dialect.all_migrations(db)
       current_applied_ids = applied_ids
 
       entries.reject! { |e| !e.id.in?(current_applied_ids) }
     end
 
     def applied?(id : Int64) : Bool
-      sql_find_migration_id = <<-SQL
-        SELECT
-          id
-        FROM
-          drift_migrations
-        WHERE
-          id = ?
-        LIMIT
-          1;
-        SQL
-
-      query_id = db.query_one?(sql_find_migration_id, id, as: Int64)
+      query_id = @dialect.find_migration_id(db, id)
 
       query_id == id
     end
 
     def applied_ids
-      sql_applied_ids = <<-SQL
-        SELECT
-          id
-        FROM
-          drift_migrations
-        ORDER BY
-          id ASC;
-        SQL
-
-      result_ids = Set{*db.query_all(sql_applied_ids, as: Int64)}
+      result_ids = Set{*@dialect.all_migration_ids(db)}
       (result_ids & Set{*context.ids}).to_a
     end
 
@@ -137,35 +113,14 @@ module Drift
     end
 
     def prepare!
-      sql_create_schema = <<-SQL
-        CREATE TABLE IF NOT EXISTS drift_migrations (
-          id INTEGER PRIMARY KEY NOT NULL,
-          batch INTEGER NOT NULL,
-          applied_at TEXT NOT NULL,
-          duration_ns INTEGER NOT NULL
-        );
-        SQL
-
       db.transaction do |tx|
         cnn = tx.connection
-        cnn.exec(sql_create_schema)
+        @dialect.create_schema!(cnn)
       end
     end
 
     def prepared? : Bool
-      sql_check_schema = <<-SQL
-        SELECT
-          name
-        FROM
-          sqlite_schema
-        WHERE
-          type = "table"
-          AND name = "drift_migrations"
-        LIMIT
-          1;
-        SQL
-
-      db.query_one?(sql_check_schema, as: String) ? true : false
+      @dialect.prepared?(db)
     end
 
     def reset!
@@ -173,17 +128,7 @@ module Drift
     end
 
     def reset_plan
-      sql_reverse_applied_plan = <<-SQL
-        SELECT
-          id
-        FROM
-          drift_migrations
-        ORDER BY
-          batch DESC,
-          id DESC;
-        SQL
-
-      batch_ids = Set{*db.query_all(sql_reverse_applied_plan, as: Int64)}
+      batch_ids = Set{*@dialect.all_migration_ids_reverse(db)}
       (batch_ids & Set{*context.ids}).to_a
     end
 
@@ -200,60 +145,24 @@ module Drift
     end
 
     def rollback_plan
-      sql_last_batch = <<-SQL
-        SELECT
-          COALESCE(
-            MAX(batch),
-            0
-          )
-        FROM
-          drift_migrations
-        LIMIT
-          1;
-        SQL
+      last_batch = @dialect.max_batch(db)
 
-      last_batch = db.query_one(sql_last_batch, as: Int64)
+      # Get all migration IDs and filter by last batch
+      all_ids = @dialect.all_migrations(db)
 
-      sql_reverse_applied_batch = <<-SQL
-        SELECT
-          id
-        FROM
-          drift_migrations
-        WHERE
-          batch = ?
-        ORDER BY
-          id DESC;
-        SQL
+      batch_ids = all_ids.select { |entry| entry.batch == last_batch }
+        .map(&.id)
+        .reverse
 
-      batch_ids = Set{*db.query_all(sql_reverse_applied_batch, last_batch, as: Int64)}
-      (batch_ids & Set{*context.ids}).to_a
+      (Set{*batch_ids} & Set{*context.ids}).to_a
     end
 
     private def apply_batch(ids : Array(Int64))
       plan_ids = Set{*ids} - Set{*applied_ids}
 
-      sql_last_batch = <<-SQL
-        SELECT
-          COALESCE(
-            MAX(batch),
-            0
-          )
-        FROM
-          drift_migrations
-        LIMIT
-          1;
-        SQL
-
-      sql_insert_migration = <<-SQL
-        INSERT INTO drift_migrations
-          (id, batch, applied_at, duration_ns)
-        VALUES
-          (?, ?, ?, ?);
-        SQL
-
       db.transaction do |tx|
         cnn = tx.connection
-        batch = cnn.query_one(sql_last_batch, as: Int64) + 1
+        batch = @dialect.max_batch(cnn) + 1
 
         plan_ids.each do |id|
           migration = context[id]
@@ -265,7 +174,7 @@ module Drift
           applied_at = Time.utc
           duration_ns = duration.total_nanoseconds.to_i64
 
-          cnn.exec(sql_insert_migration, id, batch, applied_at, duration_ns)
+          @dialect.insert_migration(cnn, id, batch, applied_at, duration_ns)
 
           # trigger after_apply callbacks
           @after_apply.each &.call(id, duration)
@@ -275,13 +184,6 @@ module Drift
 
     private def rollback_batch(ids : Array(Int64))
       plan_ids = Set{*ids} & Set{*applied_ids}
-
-      sql_delete_migration = <<-SQL
-        DELETE FROM
-          drift_migrations
-        WHERE
-          id = ?;
-        SQL
 
       db.transaction do |tx|
         cnn = tx.connection
@@ -293,7 +195,7 @@ module Drift
 
           duration = Time.measure { migration.run(:rollback, cnn) }
 
-          cnn.exec(sql_delete_migration, id)
+          @dialect.delete_migration(cnn, id)
 
           @after_rollback.each &.call(id, duration)
         end

--- a/src/drift/migrator.cr
+++ b/src/drift/migrator.cr
@@ -31,7 +31,7 @@ module Drift
     end
 
     getter context : Context
-    getter db : DB::Database | DB::Connection
+    getter db : DB::Database
 
     alias BeforeCallback = Proc(Int64, Nil)
     alias AfterCallback = Proc(Int64, Time::Span, Nil)

--- a/src/drift/migrator.cr
+++ b/src/drift/migrator.cr
@@ -147,12 +147,8 @@ module Drift
     def rollback_plan
       last_batch = @dialect.max_batch(db)
 
-      # Get all migration IDs and filter by last batch
-      all_ids = @dialect.all_migrations(db)
-
-      batch_ids = all_ids.select { |entry| entry.batch == last_batch }
-        .map(&.id)
-        .reverse
+      # Get migration IDs for last batch in reverse order
+      batch_ids = @dialect.batch_migration_ids_reverse(db, last_batch)
 
       (Set{*batch_ids} & Set{*context.ids}).to_a
     end


### PR DESCRIPTION
Drift was previously limited to SQLite3, which meant it couldn't be used by others who needed PostgreSQL or MySQL for their applications.

This PR adds support for multiple databases by introducing a `Drift::Dialect` interface that encapsulates the SQL syntax differences between SQLite3, PostgreSQL, and MySQL. Now all three databases work seamlessly with both the library API and the CLI.
