### PR TITLE
Use latest Crystal for development

### DIFF
--- a/.changes/unreleased/internal-20260119-200237.yaml
+++ b/.changes/unreleased/internal-20260119-200237.yaml
@@ -1,0 +1,5 @@
+kind: internal
+body: Develop against latest Crystal 1.19.0
+time: 2026-01-19T20:02:37.20253-03:00
+custom:
+    Issue: ""

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT_NAME := $(shell awk '/^name:/ {print $$2}' shard.yml)
 PROJECT_VERSION := $(shell awk '/^version:/ {print $$2}' shard.yml)
 
-CRYSTAL_VERSION := 1.16
+CRYSTAL_VERSION := 1.19
 FIXUID ?= $(shell id -u)
 FIXGID ?= $(shell id -g)
 


### PR DESCRIPTION
Drift is mostly agnostic of Crystal version, but is good to always test against the latest version.